### PR TITLE
Replace instances of `100 - score < 0` -> Math.max

### DIFF
--- a/lib/dom/accessibility/altImages.js
+++ b/lib/dom/accessibility/altImages.js
@@ -43,7 +43,7 @@
     title: 'Always use alt attribute on image tags',
     description: 'All img tags require an alt attribute. This goes without exception. Everything else is an error. If you have an img tag in your HTML without an alt attribute, add it now. https://www.marcozehe.de/2015/12/14/the-web-accessibility-basics/',
     advice: advice,
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     weight: 5,
     offending: offending,
     tags: ['accessibility','images']

--- a/lib/dom/accessibility/headings.js
+++ b/lib/dom/accessibility/headings.js
@@ -37,7 +37,7 @@
     title: 'Use headings tags to structure your page',
     description: 'Headings gives your document a logical, easy to follow structure. Have you ever wondered how Wikipedia puts together its table of contents for each article? They use the logical heading structure for that, too!The h1 through h6 elements are unambiguous in telling screen readers, search engines and other technologies what the structure of your document is. https://www.marcozehe.de/2015/12/14/the-web-accessibility-basics/',
     advice: message,
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     weight: 4,
     offending: [],
     tags: ['accessibility', 'html']

--- a/lib/dom/accessibility/labelOnInput.js
+++ b/lib/dom/accessibility/labelOnInput.js
@@ -33,7 +33,7 @@
     title: 'Always set labels on input in forms',
     description: 'Most input elements, as well as the select and textarea elements, need an associated label element that states the purpose. The one exception are those that produce a button, like the types of button, reset, and submit do. But every other, be it text, checkbox, password, radio (button), search etc. require a label element to be present. https://www.marcozehe.de/2015/12/14/the-web-accessibility-basics/',
     advice: score > 0 ? 'There are input that misses labels on the forms.' : '',
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     weight: 3,
     offending: offending,
     tags: ['accessibility', 'form']

--- a/lib/dom/accessibility/table.js
+++ b/lib/dom/accessibility/table.js
@@ -34,7 +34,7 @@
     title: 'Use caption and th in tables',
     description: 'Add a caption element to give the table a proper heading or summary. Use th elements to denote column and row headings. Make use of their scope and other attributes to clearly associate what belongs to which. https://www.marcozehe.de/2015/12/14/the-web-accessibility-basics/',
     advice: score > 0 ? 'The page has tables that are missing caption, please use them to give them a proper heading or summary.':'',
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     weight: 5,
     offending: offending,
     tags: ['accessibility', 'html']

--- a/lib/dom/performance/avoidScalingImages.js
+++ b/lib/dom/performance/avoidScalingImages.js
@@ -30,7 +30,7 @@
     title: 'Don\'t scale images in the browser',
     description: 'Scaling images inside the browser takes extra CPU time and will hurt performance on mobile and will make you download extra kilobytes',
     advice: message,
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     weight: 5,
     offending: offending,
     tags: ['performance','image']

--- a/lib/dom/performance/cssInHead.js
+++ b/lib/dom/performance/cssInHead.js
@@ -19,7 +19,7 @@
     title: 'Load CSS files inside the head tag',
     description: 'Keep CSS files inside of the head tag to make pages render faster',
     advice: message,
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     offending: offending,
     weight: 3,
     tags: ['performance', 'css']

--- a/lib/dom/performance/cssInHeadDomain.js
+++ b/lib/dom/performance/cssInHeadDomain.js
@@ -40,7 +40,7 @@
     title: 'Load CSS in head from document domain',
     description: 'Make sure css in head is loaded from same domain as document, in order to have a better user experience and minimize DNS lookups.',
     advice: offending.length > 0 ? 'The page got ' + offending.length + ' CSS files requested from another domain than the main document.' : '',
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     weight: 2,
     offending: offending,
     tags: ['performance', 'css']

--- a/lib/dom/performance/cssPrint.js
+++ b/lib/dom/performance/cssPrint.js
@@ -22,7 +22,7 @@
     title: 'Do not load print stylesheets, use @media type print instead',
     description: 'Loading a specific stylesheet for printing slows down the page, even though it is not used',
     advice: offending.length > 0 ? 'The page got ' + offending.length + ' print stylesheets.':'',
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     weight: 1,
     offending: offending,
     tags: ['performance', 'css']

--- a/lib/dom/performance/fastRender.js
+++ b/lib/dom/performance/fastRender.js
@@ -77,7 +77,7 @@
     title: 'Avoid slowing down the rendering critical path',
     description: 'Every file requested inside of head will postpone the rendering of the page. Try to avoid loading Javascript synchronously, request files from the same domain as the main document, and inline CSS or server push for really fast rendering.',
     advice: message,
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     weight: 10,
     offending: offending,
     tags: ['performance']

--- a/lib/dom/performance/inlineCss.js
+++ b/lib/dom/performance/inlineCss.js
@@ -45,7 +45,7 @@
     title: 'Inline CSS for faster first render on HTTP/1',
     description: 'Always inline the CSS when you use HTTP/1. Using HTTP/2 it is complicated. Do your users have a slow connection? Then it\s better to inline.',
     advice: message,
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     weight: 7,
     offending: offending,
     tags: ['performance', 'css']

--- a/lib/dom/performance/spof.js
+++ b/lib/dom/performance/spof.js
@@ -44,7 +44,7 @@
     title: 'Avoid Frontend single point of failure',
     description: 'A page should not have a single point of failure a.k.a load content from a provider that can get the page to stop working.',
     advice: offending.length > 0 ? 'The page has ' + offending.length + ' requests inside of head that can cause a SPOF. Load them async or move them outside of head.' : '',
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     weight: 7,
     offending: offending,
     tags: ['performance', 'css', 'js']

--- a/lib/dom/performance/thirdPartyAsyncJs.js
+++ b/lib/dom/performance/thirdPartyAsyncJs.js
@@ -51,7 +51,7 @@
     title: 'Always load third party Javascript asynchronously',
     description: 'Use the JavaScript snippets that load the JS files asynchronously in order to speed up the user experience',
     advice: offending.length > 0 ? 'The page got ' + offending.length + ' synchronously Javascript requests.': '',
-    score: 100 - score < 0 ? 0 : 100 - score,
+    score: Math.max(0, 100 - score),
     weight: 5,
     offending: offending,
     tags: ['performance','js']

--- a/lib/har/performance/assetsRedirects.js
+++ b/lib/har/performance/assetsRedirects.js
@@ -21,7 +21,7 @@ module.exports = {
     });
 
     return {
-      score: score < 0 ? 0 : score,
+      score: Math.max(0, score),
       offending: offending,
       advice: score < 100 ? 'The page got ' + offending.length + ' redirects. Could be some 3rd party assets that do some redirects that they really don\'t need :(' : ''
     }

--- a/lib/har/performance/cacheHeaders.js
+++ b/lib/har/performance/cacheHeaders.js
@@ -36,7 +36,7 @@ module.exports = {
     });
 
     return {
-      score: score < 0 ? 0 : score,
+      score: Math.max(0, score),
       offending: offending,
       advice: score < 100 ? 'The page got ' + offending.length + ' request(s) that are missing or have a shorter cache time than 1 month.' : ''
     }

--- a/lib/har/performance/compressAssets.js
+++ b/lib/har/performance/compressAssets.js
@@ -31,7 +31,7 @@ module.exports = {
     });
 
     return {
-      score: score < 0 ? 0 : score,
+      score: Math.max(0, score),
       offending: offending,
       advice: score < 100 ? 'The page got ' + offending.length + ' requests that are served uncompressed. You can save a lot of bytes by sending them compressed instead.' : ''
     }

--- a/lib/har/performance/connectionKeepAlive.js
+++ b/lib/har/performance/connectionKeepAlive.js
@@ -28,7 +28,7 @@ module.exports = {
       }
     });
     return {
-      score: score < 0 ? 0 : score,
+      score: Math.max(0, score),
       offending: offending,
       advice : score < 100 ? 'The page got ' + offending.length + ' requests that are done to a domain where the connection already has been closed. Don\'t close the connection and reuse the connection!' : ''
     }

--- a/lib/har/performance/favicon.js
+++ b/lib/har/performance/favicon.js
@@ -48,7 +48,7 @@ module.exports = {
     // TODO add the reason why we report error on the favicon
 
     return {
-      score: score < 0 ? 0 : score,
+      score: Math.max(0, score),
       offending: offending,
       advice: score < 100 ? 'The favicon should be small and cacheable.' : ''
     }

--- a/lib/har/performance/fewRequestsPerDomain.js
+++ b/lib/har/performance/fewRequestsPerDomain.js
@@ -27,7 +27,7 @@ module.exports = {
     });
 
     return {
-      score: score < 0 ? 0 : score,
+      score: Math.max(0, score),
       offending: offending,
       advice: score < 100 ? 'The page got ' + offending.length + ' domains that serves more than 30 requests. Improve performance by sharding those or move to HTTP/2.' : ''
     }

--- a/lib/har/performance/headerSize.js
+++ b/lib/har/performance/headerSize.js
@@ -17,7 +17,7 @@ module.exports = {
       }
     });
     return {
-      score: score < 0 ? 0 : score,
+      score: Math.max(0, score),
       offending: offending,
       advice: score < 100 ? 'The page got ' + offending.length + ' responses with a header size larger than ' + limit + ' bytes. You should really look into how to minimize the number of cookies sent.' : ''
     };

--- a/lib/har/performance/privateAssets.js
+++ b/lib/har/performance/privateAssets.js
@@ -30,7 +30,7 @@ module.exports = {
     });
 
     return {
-      score: score < 0 ? 0 : score,
+      score: Math.max(0, score),
       offending: offending,
       advice: score < 100 ? 'The page got ' + offending.length + ' requests with private headers. That doesn\'t seems to be right, they are cacheable for that specific user and not for everyone.' : ''
     }

--- a/lib/har/performance/responseOk.js
+++ b/lib/har/performance/responseOk.js
@@ -35,7 +35,7 @@ module.exports = {
     });
 
     return {
-      score: score < 0 ? 0 : score,
+      score: Math.max(0, score),
       offending: offending,
       advice: score < 100 ? 'The page got ' + errors + ' 50X and ' + missing + ' 40X.' : ''
     }


### PR DESCRIPTION
In some rules, the `result.score` key was using a ternary operator to detect if
`100 - score` was `< 0`, and if it was, then the property would be set to 0.

A better way to handle this is Math.max:

```js
score = 80;
(100 - score < 0 ? 0 : 100 - score) === 20
Math.max(0, 100 - score) === 20

score = 150
(100 - score < 0 ? 0 : 100 - score) === 0
Math.max(0, 100 - score) === 0
```
