### PR TITLE
Grammar tweak to notification copy

### DIFF
--- a/help/large.json
+++ b/help/large.json
@@ -379,7 +379,7 @@
           "weight": 8
         },
         "sections": {
-          "advice": "The page doesn't use sections. You could possible use them to get a better structure of your content.",
+          "advice": "The page doesn't use sections. You could use them to get a better structure of your content.",
           "description": "Section tags should have at least one heading element as a direct descendant.",
           "id": "sections",
           "offending": [

--- a/help/small.json
+++ b/help/small.json
@@ -74,7 +74,7 @@
           "weight": 8
         },
         "sections": {
-          "advice": "The page doesn't use sections. You could possible use them to get a better structure of your content.",
+          "advice": "The page doesn't use sections. You could use them to get a better structure of your content.",
           "description": "Section tags should have at least one heading element as a direct descendant.",
           "id": "sections",
           "offending": [

--- a/lib/dom/accessibility/sections.js
+++ b/lib/dom/accessibility/sections.js
@@ -7,7 +7,7 @@
   var totalSections = sections.length;
 
   if (totalSections === 0) {
-    message = 'The page doesn\'t use sections. You could possible use them to get a better structure of your content.';
+    message = 'The page doesn\'t use sections. You could use them to get a better structure of your content.';
     score = 100;
   } else {
     sections.forEach(function(section) {


### PR DESCRIPTION
No code changes in this PR. This is purely a copy change to clean up the "The page doesn't use sections" grammar.

An alternate would be to change "could possible" to "could possibly"; the proposed change (dropping "possible") is cleaner and more confident.