### PR TITLE
noColor command line switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ webcoach https://www.sitespeed.io -f json
 ```
 This will get you the full JSON, the same as if you integrate the coach into your tool.
 
+> ... but hey, I don't want any color in the table output?
+
+That's possible as well!
+```bash
+webcoach https://www.sitespeed.io --noColor
+```
 
 ### sitespeed.io 4.0
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -55,6 +55,11 @@ var cli = {
         default: false,
         type: 'boolean'
       })
+      .option('noColor', {
+        describe: 'Do not print color information.',
+        default: false,
+        type: 'boolean'
+      })
       .wrap(yargs.terminalWidth())
       // .strict()
       .argv;

--- a/lib/table.js
+++ b/lib/table.js
@@ -34,6 +34,10 @@ class ResultTable {
   }
 
   setupAdviceTable(type) {
+    if (this.options.noColor) {
+      chalk.enabled = false;
+    }
+
     let names = {
       performance: 'Performance advice',
       accessibility: 'Accessibility advice',


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Check that your change/fix has corresponding unit tests: n/a
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
Add a `noColor` command line switch to turn off colorized output in the table format (or any other format that comes along and uses ANSI color codes).

Document the new option in the README.

This resolves #110.