### PR TITLE
Add appveyor.yml for Windows testing via AppVeyor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The coach
 
-[![Build status][travis-image]][travis-url]
+[![Build status Linux][travis-image]][travis-url]
+[![Build status Windows][appveyor-image]][appveyor-url]
 [![Downloads][downloads-image]][downloads-url]
 [![Docker][docker-image]][docker-url]
 [![Stars][stars-image]][stars-url]
@@ -254,11 +255,13 @@ The coach is automatically tested in latest Chrome and Firefox. To get best resu
 We hope that the coach works in other browsers but we cannot guarantee it right now.
 
 
-[travis-image]: https://img.shields.io/travis/sitespeedio/coach.svg?style=flat-square
+[travis-image]: https://img.shields.io/travis/sitespeedio/coach.svg?style=flat-square&label=Linux%20build
 [travis-url]: https://travis-ci.org/sitespeedio/coach
+[appveyor-image]: https://img.shields.io/appveyor/ci/XhmikosR/mpc-hc-org/master.svg?style=flat-square&label=Windows%20build
+[appveyor-url]: https://ci.appveyor.com/project/XhmikosR/coach/history
 [stars-url]: https://github.com/sitespeedio/coach/stargazers
 [stars-image]: https://img.shields.io/github/stars/sitespeedio/coach.svg?style=flat-square
 [downloads-image]: http://img.shields.io/npm/dm/webcoach.svg?style=flat-square
 [downloads-url]: https://npmjs.org/package/webcoach
-[docker-image]: https://img.shields.io/docker/pulls/sitespeedio/coach.svg
+[docker-image]: https://img.shields.io/docker/pulls/sitespeedio/coach.svg?style=flat-square
 [docker-url]: https://hub.docker.com/r/sitespeedio/coach/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+# http://www.appveyor.com/docs/appveyor-yml
+
+version: "{build}"
+
+clone_depth: 10
+
+build: off
+
+environment:
+  matrix:
+    - nodejs_version: "6"
+      platform: x86
+
+install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm config set spin false
+  - npm install
+  - npm install win-detect-browsers
+
+test_script:
+  - node_modules\.bin\win-detect-browsers.cmd
+  - npm run lint
+  - npm test
+  - node ./bin/webcoach.js -b chrome https://www.sitespeed.io > output.json
+  - node ./bin/webcoach.js -b firefox https://www.sitespeed.io > output.json
+  - node ./bin/webcoach.js -b chrome --mobile https://www.sitespeed.io > output.json
+
+matrix:
+  fast_finish: true
+
+cache:
+  - 'node_modules -> appveyor.yml,package.json'

--- a/test/help/webserver.js
+++ b/test/help/webserver.js
@@ -36,8 +36,9 @@ module.exports = {
     if (!server) {
       server = createServer(useHttp2);
     }
+    const ADDRESS = process.platform === 'win32' ? 'localhost' : '0.0.0.0';
     return new Promise((resolve, reject) => {
-      server.listen(0, '0.0.0.0')
+      server.listen(0, ADDRESS)
         .on('error', (e) => reject(e))
         .on('listening', () => resolve(server.address()));
     });


### PR DESCRIPTION
Before merging, make sure you add AppVeyor to the project, and enable "Skip branches without appveyor.yml" in settings.

I couldn't find a clean way to show the browsers' version number so I added win-detect-browsers.
This worked only for Firefox, Chrome made the build stuck.

``` yml
before_test:
  - '"C:\Program Files (x86)\Mozilla Firefox\firefox.exe" -version>ff_version.txt && type ff_version.txt'
  - '"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --version'
```

On a side note, shouldn't you test the minimum supported node.js version too (0.10 at the time of writing)? Otherwise, how will you know if it breaks?

Fixes #118.
Fixes #195.
