### PR TITLE
table.js: use `\n` instead of EOL.

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -3,8 +3,7 @@
 var wrap = require('word-wrap');
 
 var Table = require('cli-table2'),
-  chalk = require('chalk'),
-  EOL = require("os").EOL;
+  chalk = require('chalk');
 
 function getNewTable() {
   return new Table({
@@ -81,7 +80,7 @@ class ResultTable {
         if (adviceList[advice].offending.length > 0 && self.options.details) {
           self.table.push([{
             'colSpan': 3,
-            'content': adviceList[advice].offending.join(EOL)
+            'content': adviceList[advice].offending.join('\n')
           }])
         }
       }


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/349621/15778510/58422026-299f-11e6-850e-6840a8c7695b.png)

After:
![after](https://cloud.githubusercontent.com/assets/349621/15778513/5b28b4f8-299f-11e6-99a9-59dfc8d0da60.png)

I was getting a `CR` which is `\r` after each asset. Every other line is `LF` (`\n`) even on Windows.
Not sure what happens on OSX.
