### PR TITLE
Fixing the labelOnInput advice

### DIFF
--- a/lib/dom/accessibility/labelOnInput.js
+++ b/lib/dom/accessibility/labelOnInput.js
@@ -3,24 +3,37 @@
 
   function getMatchingLabel(id, labels) {
     return labels.filter(function(entry) {
-      return entry.for && entry.for === id;
+      return entry.attributes.for && entry.attributes.for.value === id;
     });
+  }
+
+  function hasLabel(input, labels) {
+    return input.id && getMatchingLabel(input.id, labels).length > 0;
+  }
+
+  function isExcluded(input, excludedInputTypes) {
+    return excludedInputTypes.includes(input.type);
+  }
+
+  function isInsideLabel(input) {
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
+    return input.parentElement.nodeName === 'LABEL';
   }
 
   var labels = Array.prototype.slice.call(window.document.getElementsByTagName('label'));
 
   var score = 0;
   var offending = [];
-  var inputs = Array.prototype.slice.call(window.document.getElementsByTagName('input'));
+  var inputs = Array.prototype.slice.call(window.document.querySelectorAll('input, textarea, select'));
+  var excludedInputTypes = ['button', 'hidden', 'image', 'reset', 'submit'];
 
   inputs.forEach(function(input) {
-    if (input.type === 'text' || input.type === 'password' || input.type === 'radio' || input.type === 'checkbox' || input.type === 'search') {
-
-      // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
-      if (input.parentElement.nodeName !== 'LABEL' && (input.id && getMatchingLabel(input.id, labels).length === 0)) {
-        score += 10;
-      }
+    if (isExcluded(input, excludedInputTypes) || isInsideLabel(input) || hasLabel(input, labels)) {
+      return;
     }
+
+    offending.push(input.id || input.name || input.outerHTML);
+    score += 10;
   });
 
   return {

--- a/test/dom/accessibility/indexTest.js
+++ b/test/dom/accessibility/indexTest.js
@@ -35,7 +35,19 @@ describe('Accessibility', function() {
       it('We should be able to know if you miss adding a label on an input field', function() {
         return runner.run('labelOnInput.js')
           .then((result) => {
-            assert.strictEqual(result.score, 90);
+            assert.strictEqual(result.score, 60);
+          });
+      });
+
+      it('We should be able to know which input fields are missing a label', function() {
+        return runner.run('labelOnInput.js')
+          .then((result) => {
+            assert.deepEqual(result.offending, [
+              "test-text-missing",
+              "missingUrl",
+              "test-select-missing",
+              "test-textarea-missing"
+            ]);
           });
       });
 

--- a/test/http-server/accessibility/labelOnInput.html
+++ b/test/http-server/accessibility/labelOnInput.html
@@ -65,10 +65,78 @@ Right on for the darkness
 Right on for the darkness
  </pre>
   <form>
-    <label>Click me <input type="text" name="hepp"></label>
-    <label for="username">Click me</label>
-    <input type="text" id="username">
-    <input type='search' name='search'>
+    <label for="test-checkbox"><input type="checkbox" id="test-checkbox"> Label</label>
+
+    <label for="test-color">Label</label>
+    <input type="color" id="test-color">
+
+    <label for="test-date">Label</label>
+    <input type="date" id="test-date">
+
+    <label for="test-datetime">Label</label>
+    <input type="datetime" id="test-datetime">
+
+    <label for="test-datetime-local">Label</label>
+    <input type="datetime-local" id="test-datetime-local">
+
+    <label for="test-email">Label</label>
+    <input type="email" id="test-email">
+
+    <label for="test-file">Label</label>
+    <input type="file" id="test-file">
+
+    <label for="test-image">Label</label>
+    <input type="image" id="test-image">
+
+    <label for="test-month">Label</label>
+    <input type="month" id="test-month">
+
+    <label for="test-number">Label</label>
+    <input type="number" id="test-number">
+
+    <label for="test-password">Label</label>
+    <input type="password" id="test-password">
+
+    <label for="test-radio"><input type="radio" id="test-radio"> Label</label>
+
+    <label for="test-range">Label</label>
+    <input type="range" id="test-range">
+
+    <label for="test-search">Label</label>
+    <input type="search" id="test-search">
+
+    <label for="test-tel">Label</label>
+    <input type="tel" id="test-tel">
+
+    <label for="test-text">Click me</label>
+    <input type="text" id="test-text">
+
+    <label for="test-time">Label</label>
+    <input type="time" id="test-time">
+
+    <label for="test-url">Label</label>
+    <input type="url" id="test-url">
+
+    <label for="test-week">Label</label>
+    <input type="week" id="test-week">
+
+    <label for="test-select">Label</label>
+    <select id="test-select"></select>
+
+    <label for="test-textarea">Label</label>
+    <textarea id="test-textarea"></textarea>
+
+    <!-- Those should be ignored -->
+    <input type="button" id="test-button">
+    <input type="hidden" id="test-hidden">
+    <input type="reset" id="test-reset">
+    <input type="submit" id="test-submit">
+
+    <!-- Those should be offending -->
+    <input type="text" id="test-text-missing">
+    <input type="url" name="missingUrl">
+    <select id="test-select-missing"></select>
+    <textarea id="test-textarea-missing"></textarea>
   </form>
 </body>
 </html>


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [X] Check that your change/fix has corresponding unit tests
- [X] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description

This PR fixes the labelOnInput by treating the following points
that were making broken and unhelpful:

* it doesn't check `textarea` and `select`
* it whitelists the input types instead of excluding those that don't need a label
* labels `for` attributes always returns `undefined` it should be `entry.attributes.for.value`
* the `offending` array is not filled with the `id` or `name` of the offending inputs