### PR TITLE
Add viewPort option to set browser window size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - webcoach
 
+## UNRELEASED
+### Added
+- Add --viewPort option to set browser window size for test
+
 ## 0.29.0 2016-11-11
 ### Changed
 - Updated NodeJs dependency to be 6.9.1 (needed when we start to use Selenium 3.0.0)

--- a/bin/webcoach.js
+++ b/bin/webcoach.js
@@ -16,7 +16,9 @@ function run(options) {
   function setupOptions(options) {
     options.iterations = 1;
     if (options.mobile) {
-      options.viewPort = '360x640';
+      if (!options.viewPort) {
+          options.viewPort = '360x640';
+      }
       if (options.browser === 'chrome') {
         options.chrome = {
           mobileEmulation: {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -63,6 +63,9 @@ var cli = {
       .option('preScript', {
         describe: 'Task(s) to run before you test your URL (use it for login etc). Note that --preScript can be passed multiple times.'
       })
+      .option('viewPort', {
+        describe: 'Set the browser viewport to WIDTHxHEIGHT.'
+      })
       .wrap(yargs.terminalWidth())
       // .strict()
       .argv;


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

I couldn't find any existing tests for CLI options.

- [ ] Check that your change/fix has corresponding unit tests
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`
- [x] Squash commits so it looks sane

### Description

Add viewPort option to set browser window size

Fixes #208.