### PR TITLE
resolves sitespeedio/coach#204 - pull request to add reporting advice…

### DIFF
--- a/lib/har/performance/mimeTypes.js
+++ b/lib/har/performance/mimeTypes.js
@@ -1,0 +1,23 @@
+'use strict';
+module.exports = {
+  id: 'mimeTypes',
+  title: 'Avoid using incorrect mime types',
+  description: 'It\'s not a great idea to let browsers guess content types (content sniffing), in some cases it can actually be a security risk.',
+  weight: 0,
+  tags: ['performance', 'bestpractice'],
+  processPage: function(page) {
+    let score = 100;
+    let offending = [];
+    page.assets.forEach(function(asset) {
+        if (asset.type == "other" && (asset.status >199 && asset.status < 300)) {
+            score--;
+            offending.push(asset.url);
+        }
+    });
+    return {
+      score: Math.max(0, score),
+      offending: offending,
+      advice: score < 100 ? 'The page has ' + offending.length + ' misconfigured mime type(s). ' : ''
+    };
+  }
+};

--- a/test/har/files/mimeTypesCorrect.har
+++ b/test/har/files/mimeTypesCorrect.har
@@ -1,0 +1,2083 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-01-19T06:46:30.145Z",
+        "id": "page_5",
+        "title": "https://run.sitespeed.io/",
+        "pageTimings": {
+          "onContentLoad": 220.09099999559112,
+          "onLoad": 421.81800000253133
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-01-19T06:46:30.145Z",
+        "time": 117.03599998145364,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "upgrade-insecure-requests",
+              "value": "1"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "x-response-time",
+              "value": "19.948ms"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"2jB3aYr1qW9k73mquCnXUA==\""
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 12311,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html lang=en><head><meta charset=utf-8><meta name=viewport content=\"initial-scale=1\"><title>Analyze your page against web performance best practice rules and using metrics</title><link rel=apple-touch-icon-precomposed sizes=144x144 href=/img/ico/sitespeed.io-144.png><link rel=apple-touch-icon-precomposed sizes=114x114 href=/img/ico/sitespeed.io-114.png><link rel=apple-touch-icon-precomposed sizes=72x72 href=/img/ico/sitespeed.io-72.png><link rel=apple-touch-icon-precomposed href=/img/ico/sitespeed.io-57.png><link rel=\"shortcut icon\" href=/img/ico/sitespeed.io.ico><meta name=description content=\"How fast is your site? How good does it follow web performance best practice rules? Find out by using sitespeed.io.\"><meta name=keywords content=\"sitespeed.io, wpo, webperf, perfmatters, performance\"><style>*{-moz-box-sizing:border-box;box-sizing:border-box;line-height:1.5em}html{height:100%}div,p,a,li,td,span{-webkit-text-size-adjust:none;font-family:Verdana,sans-serif;-webkit-box-sizing:border-box}h1{font-weight:700;font-size:30px;margin:0}h2{font-weight:700;font-size:20px}body{margin:0;padding:0;height:100%;font-size:14px;padding-bottom:72px}a{color:#428bca;text-decoration:none}form a{color:#fff;text-decoration:underline}#container{min-height:100%;position:relative;background:#fff}.homelink{text-indent:-9999px;display:block}footer{background-color:#e1f6fd}#footer-wrapper{float:left}.footerlist{color:#00517c;overflow:hidden;margin:0}.footerlist li{float:left;list-style-type:none;padding:5px 10px}footer .homelink{background:transparent url(../img/logos/logoFooter.svg) 0 center / contain no-repeat}.footerlist li a{color:#00517c;padding:0;text-decoration:none;display:block}#footerlinks{float:left}#footershare{float:right}#footershare li{margin:10px 0}#footershare li a{display:block}#footershare .facebook a{background:transparent url(../img/socialmedia/facebook-round.svg) center center /contain no-repeat}#footershare .twitter a{background:transparent url(../img/socialmedia/twitter-round.svg) center center /contain no-repeat}#footershare .github a{background:transparent url(../img/socialmedia/github-round.svg) center center /contain no-repeat}.photo{border-radius:10px;margin-right:20px;margin-bottom:10px}.pull-left{float:left!important}body#start{border-top-width:18px}#start header{background-color:transparent;margin-top:0}#start #page:before{display:none}#start header:before{display:none}#start #content{background:transparent url(../img/logos/logoBig2.svg) 0 0 / 100% no-repeat}#start #container{background:#0095d2 url(../img/bg_cat.png) 75% 36px no-repeat}#analyze-form{color:#fff;width:100%;overflow:hidden}#analyze-form label{width:100%;display:block}#analyze-form select,#analyze-url{color:#000;padding:.5em;margin-bottom:1em;display:block;width:100%;font-size:16px;-webkit-appearance:none;-moz-appearance:none;appearance:none;-webkit-border-radius:7px;-moz-border-radius:7px;border-radius:7px;border:1px solid #dfdfdf;background:#fff}#analyze-url{width:100%}#analyze-form select{background:#fff url(../img/arrow_down.svg) right center /14px auto no-repeat}input[type=submit],button{font-size:18px;border:0 none;padding:.25em 1em;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;-webkit-appearance:none;-moz-appearance:none;appearance:none;cursor:pointer}#analyze-form input[type=submit]{background-color:#ffd100;float:right}#randomcats{overflow:hidden;margin:0 auto;position:relative}#randomtexts{padding-top:10px;padding-bottom:10px}#randomcats img{width:100%;height:auto;position:absolute;top:-9999px;bottom:-9999px;left:-9999px;right:-9999px;margin:auto}.result-button{color:#fff;margin:20px 0}#result-see-details{background-color:#da251d}#result-download{background-color:#0093dd}#stars{margin:10px 0 20px;letter-spacing:1vw}#bad-result #stars{color:#da251d}#good-result #stars{color:#e88829}#great-result #stars{color:#468847}#hero #stars{color:#468847}#share{overflow:hidden;padding:0}#share:before{width:130px;height:100px;display:block;content:\"\";background:transparent url(../img/cat/cat_share_this.svg) left center /contain no-repeat}#share li{float:left;padding:30px 1vw;width:15%;list-style-type:none}#share li a{display:block;height:40px;text-indent:-9999px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}#share .facebook a{background:#3b5998 url(../img/socialmedia/facebook.svg) center center /contain no-repeat}#share .twitter a{background:#00aced url(../img/socialmedia/twitter.svg) center center /contain no-repeat}#share .googleplus a{background:#dd4b39 url(../img/socialmedia/googleplus.svg) center center /contain no-repeat}#share .linkedin a{background:#007bb6 url(../img/socialmedia/linkedin.svg) center center /contain no-repeat}#share .pinterest a{background:#cb2027 url(../img/socialmedia/pinterest.svg) center center /contain no-repeat}@media only screen and (min-width:769px){body{border-top:48px solid #0095d2;background-color:#e1f6fd}#page,header,footer{width:100%;max-width:1280px;margin:0 auto}#page{padding-left:10px;min-height:300px;overflow:hidden}body:not(#start) #page:before{content:\"\";max-width:255px;max-height:255px;width:20vw;height:20vw;float:left}#content{margin:3% 20px 20px 21%;min-height:250px;-webkit-border-radius:10px;-moz-border-radius:10px;border-radius:10px;background-color:#e1f6fd;padding:20px;font-size:20px;line-height:1.5}#start #content{width:50%;min-width:550px;margin:0 auto;padding-top:150px}#dashboard #page:before{background:transparent url(../img/cat/dashboard.svg) 0 0 / contain no-repeat}#flash #page:before{background:transparent url(../img/cat/flash.svg) 0 0 / contain no-repeat}#extra #page:before{background:transparent url(../img/cat/cat_with_gears.svg) 0 0 / contain no-repeat}#faq #page:before{background:transparent url(../img/cat/magician.svg) 0 0 / contain no-repeat}#process #page:before{background:transparent url(../img/cat/cat_inspecting.svg) 0 0 / contain no-repeat}#bad-result #page:before{background:transparent url(../img/cat/cat_bad_result.svg) 0 0 / contain no-repeat}#good-result #page:before{background:transparent url(../img/cat/cat_good_result.svg) 0 0 / contain no-repeat}#hero #page:before{background:transparent url(../img/cat/captainSitespeed.io.svg) 0 0 / contain no-repeat}#top{width:100%;border-top:26px solid #0095d2;background-color:#fff;margin-right:50%;width:50%}header{background-color:#fff;border-top:36px solid #0095d2;margin-top:-62px;height:80px}header .homelink{background:#0095d2 url(../img/logos/logoHeader.svg) 10px 0 / 70% auto no-repeat;width:295px;height:62px;margin-top:-36px;margin-right:10px;position:relative;z-index:2}header .homelink:after{background:transparent url(../img/tabshape.svg) 0 0 / cover no-repeat;content:\"\";width:76px;height:28px;margin-top:34px;float:right;z-index:1}#analyze-form label{width:100%;padding-right:15%;display:block;overflow:hidden}#analyze-form span{float:left;padding-top:.5em;font-size:16px}#analyze-form input[type=submit]{margin-right:15%;font-size:24px}#analyze-form input[type=text]{font-size:24px}#analyze-form input[type=url]{font-size:24px}#analyze-form select{width:60%;float:right}#randomcats{width:71vw;height:32vw;max-width:100%;max-height:490px}#result-see-details{margin-right:10px}#stars{font-size:50px}#share:before{float:left}footer{height:72px;bottom:-72px;padding-left:10px;position:absolute;left:0;right:0}footer .homelink{max-width:215px;width:20%;height:100%;float:left}#footerlinks{padding:24px 10px 0 10px}#footershare li a{width:40px;height:40px}}@media only screen and (max-width:768px){body{font-size:16px;background-color:#0095d2}#page,header,.footerlist{max-width:100%}#page{overflow:hidden}#start #page{border:10px solid #0095d2}#content{margin-left:0;margin:10px 0 0;padding:13px}#container{background-color:#0095d2;padding-bottom:20px}#start #container{background-size:contain}#start #content{width:100%;padding-top:20vw;border:1vw solid #0095d2}body:not(#start) #page{-webkit-border-radius:10px 10px 0 0;-moz-border-radius:10px 10px 0 0;border-radius:10px 10px 0 0;background-color:#fff;margin:3vw 3vw 0;width:auto}#top{display:none}header .homelink{background:#0095d2 url(../img/logos/logoHeaderMobile.svg) center bottom / contain no-repeat;height:70px;border:10px solid #0095d2}h1{font-size:26px}#extra h1#box-title:after{background:transparent url(../img/cat/cat_with_gears.svg) center 0 / contain no-repeat}#dashboard h1#box-title:after{background:transparent url(../img/cat/dashboard.svg) center 0 / contain no-repeat}#flash h1#box-title:after{background:transparent url(../img/cat/flash.svg) center 0 / contain no-repeat}#faq h1#box-title:after{background:transparent url(../img/cat/magician.svg) center 0 / contain no-repeat}#extra h1#box-title:after{background:transparent url(../img/cat/cat_with_gears.svg) center 0 / contain no-repeat}#bad-result h1#box-title:after{background:transparent url(../img/cat/cat_bad_result.svg) center 0 / contain no-repeat}#good-result h1#box-title:after{background:transparent url(../img/cat/cat_good_result.svg) center 0 / contain no-repeat}#great-result h1#box-title:after{background:transparent url(../img/cat/cat_great_result.svg) center 0 / contain no-repeat}#hero h1#box-title:after{background:transparent url(../img/cat/captainSitespeed.io.svg) center 0 / contain no-repeat}#analyze-form{margin-bottom:3em}#analyze-form input[type=submit]{width:100%;padding:.5em 1em}#randomcats{width:87vw;height:39vw;margin-bottom:2vw}.resultpage #analyze-url{border-color:#bfe6f2;margin-bottom:3em}#stars{font-size:9vw}.result-button{width:45%;padding:1em}#result-download{float:right}#share:before{margin:0 auto}#share li{width:20%}#share li a{height:50px}footer{font-size:16px;overflow:hidden;margin-bottom:20px;text-align:center}body:not(#start) footer{margin:0 3vw 3vw;-webkit-border-radius:0 0 10px 10px;-moz-border-radius:0 0 10px 10px;border-radius:0 0 10px 10px}footer .homelink{bottom:0;left:0;margin:0 auto 7px;position:absolute;right:0;width:24%}#footershare{width:100%;float:none;padding:0}#footershare li{display:inline;float:none}#footershare li a{display:inline-block;margin:1em 0;width:60px;height:60px}#footerlinks{width:100%;height:auto;padding:0}#footerlinks li{width:100%;float:none;text-align:center;padding:1em;border-bottom:1px solid #bfe6f2}}</style></head><body id=start><script>!function(e,a,t,n,c,o,s){e.GoogleAnalyticsObject=c,e[c]=e[c]||function(){(e[c].q=e[c].q||[]).push(arguments)},e[c].l=1*new Date,o=a.createElement(t),s=a.getElementsByTagName(t)[0],o.async=1,o.src=n,s.parentNode.insertBefore(o,s)}(window,document,\"script\",\"//www.google-analytics.com/analytics.js\",\"ga\"),ga(\"create\",\"UA-31246987-3\",\"auto\"),ga(\"send\",\"pageview\");</script><div id=container><div id=page><div id=content><form id=analyze-form method=post action=\"/\"><input id=analyze-url name=url type=url required pattern=https?://.+ placeholder=\"http(s)://\" title=\"Add a URL starting with http(s)://\"><label><span>Browser:</span><select name=browser><option value=firefox selected=selected>Firefox [41]</option><option value=chrome>Chrome [45]</option></select></label><label><span>Location:</span><select name=location><option value=nyc>New York [USA]</option><option value=sf>San Francisco [USA]</option><option value=amsterdam>Amsterdam [Netherlands]</option><option value=singapore>Singapore [Singapore]</option></select></label><label><span>Connection type:</span><select name=connection><option value=mobile3g>mobile3g</option><option value=mobile3gfast>mobile3g fast</option><option value=cable selected=selected>cable</option><option value=native>native</option></select></label><input type=submit value=\"Start analyzing\"></form></div></div><footer><a class=homelink href=\"/\">Sitespeed.io</a><ul id=footerlinks class=footerlist><li><a href=\"/\">Home</a></li><li><a href=\"/about/\">About</a></li><li><a href=\"/sponsors/\">Sponsors</a></li><li><a href=\"/dashboard/\">Dashboard</a></li><li><a href=\"/faq/\">FAQ</a></li></ul><ul id=footershare class=\"socialcount footerlist\"><li class=facebook><a href=https://www.facebook.com/sitespeed.io title=\"Like on Facebook\"></a></li><li class=twitter><a href=https://twitter.com/sitespeedio title=\"Follow on Twitter\"></a></li><li class=github><a href=https://github.com/sitespeedio/sitespeed.io title=\"Star on Github\"></a></li></ul></footer></div></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 4019
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.421999982791021,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.20000000949949093,
+          "wait": 114.40699998638549,
+          "receive": 2.0070000027776445,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.313Z",
+        "time": 6.945999979507178,
+        "request": {
+          "method": "GET",
+          "url": "https://www.google-analytics.com/analytics.js",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/analytics.js"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "www.google-analytics.com"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:18:44 GMT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "last-modified",
+              "value": "Thu, 05 Nov 2015 22:24:16 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Golfe2"
+            },
+            {
+              "name": "age",
+              "value": "1662"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-type",
+              "value": "text/javascript"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=7200"
+            },
+            {
+              "name": "content-length",
+              "value": "10930"
+            },
+            {
+              "name": "expires",
+              "value": "Tue, 19 Jan 2016 08:18:44 GMT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 26285,
+            "mimeType": "text/javascript",
+            "text": "(function(){var $c=function(a){this.w=a||[]};$c.prototype.set=function(a){this.w[a]=!0};$c.prototype.encode=function(){for(var a=[],b=0;b<this.w.length;b++)this.w[b]&&(a[Math.floor(b/6)]^=1<<b%6);for(b=0;b<a.length;b++)a[b]=\"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_\".charAt(a[b]||0);return a.join(\"\")+\"~\"};var vd=new $c;function J(a){vd.set(a)}var Nd=function(a,b){var c=new $c(Dd(a));c.set(b);a.set(Gd,c.w)},Td=function(a){a=Dd(a);a=new $c(a);for(var b=vd.w.slice(),c=0;c<a.w.length;c++)b[c]=b[c]||a.w[c];return(new $c(b)).encode()},Dd=function(a){a=a.get(Gd);ka(a)||(a=[]);return a};var ea=function(a){return\"function\"==typeof a},ka=function(a){return\"[object Array]\"==Object.prototype.toString.call(Object(a))},qa=function(a){return void 0!=a&&-1<(a.constructor+\"\").indexOf(\"String\")},D=function(a,b){return 0==a.indexOf(b)},sa=function(a){return a?a.replace(/^[\\s\\xa0]+|[\\s\\xa0]+$/g,\"\"):\"\"},ta=function(a){var b=M.createElement(\"img\");b.width=1;b.height=1;b.src=a;return b},ua=function(){},K=function(a){if(encodeURIComponent instanceof Function)return encodeURIComponent(a);J(28);return a},\nL=function(a,b,c,d){try{a.addEventListener?a.addEventListener(b,c,!!d):a.attachEvent&&a.attachEvent(\"on\"+b,c)}catch(e){J(27)}},wa=function(a,b){if(a){var c=M.createElement(\"script\");c.type=\"text/javascript\";c.async=!0;c.src=a;b&&(c.id=b);var d=M.getElementsByTagName(\"script\")[0];d.parentNode.insertBefore(c,d)}},Ud=function(){return\"https:\"==M.location.protocol},xa=function(){var a=\"\"+M.location.hostname;return 0==a.indexOf(\"www.\")?a.substring(4):a},ya=function(a){var b=M.referrer;if(/^https?:\\/\\//i.test(b)){if(a)return b;\na=\"//\"+M.location.hostname;var c=b.indexOf(a);if(5==c||6==c)if(a=b.charAt(c+a.length),\"/\"==a||\"?\"==a||\"\"==a||\":\"==a)return;return b}},za=function(a,b){if(1==b.length&&null!=b[0]&&\"object\"===typeof b[0])return b[0];for(var c={},d=Math.min(a.length+1,b.length),e=0;e<d;e++)if(\"object\"===typeof b[e]){for(var g in b[e])b[e].hasOwnProperty(g)&&(c[g]=b[e][g]);break}else e<a.length&&(c[a[e]]=b[e]);return c};var ee=function(){this.keys=[];this.values={};this.m={}};ee.prototype.set=function(a,b,c){this.keys.push(a);c?this.m[\":\"+a]=b:this.values[\":\"+a]=b};ee.prototype.get=function(a){return this.m.hasOwnProperty(\":\"+a)?this.m[\":\"+a]:this.values[\":\"+a]};ee.prototype.map=function(a){for(var b=0;b<this.keys.length;b++){var c=this.keys[b],d=this.get(c);d&&a(c,d)}};var O=window,M=document;var Aa=function(a){var b=O._gaUserPrefs;if(b&&b.ioo&&b.ioo()||a&&!0===O[\"ga-disable-\"+a])return!0;try{var c=O.external;if(c&&c._gaUserPrefs&&\"oo\"==c._gaUserPrefs)return!0}catch(d){}return!1};var Ca=function(a){var b=[],c=M.cookie.split(\";\");a=new RegExp(\"^\\\\s*\"+a+\"=\\\\s*(.*?)\\\\s*$\");for(var d=0;d<c.length;d++){var e=c[d].match(a);e&&b.push(e[1])}return b},zc=function(a,b,c,d,e,g){e=Aa(e)?!1:eb.test(M.location.hostname)||\"/\"==c&&vc.test(d)?!1:!0;if(!e)return!1;b&&1200<b.length&&(b=b.substring(0,1200),J(24));c=a+\"=\"+b+\"; path=\"+c+\"; \";g&&(c+=\"expires=\"+(new Date((new Date).getTime()+g)).toGMTString()+\"; \");d&&\"none\"!=d&&(c+=\"domain=\"+d+\";\");d=M.cookie;M.cookie=c;if(!(d=d!=M.cookie))a:{a=\nCa(a);for(d=0;d<a.length;d++)if(b==a[d]){d=!0;break a}d=!1}return d},Cc=function(a){return K(a).replace(/\\(/g,\"%28\").replace(/\\)/g,\"%29\")},vc=/^(www\\.)?google(\\.com?)?(\\.[a-z]{2})?$/,eb=/(^|\\.)doubleclick\\.net$/i;var oc=function(){return(Ba||Ud()?\"https:\":\"http:\")+\"//www.google-analytics.com\"},Da=function(a){this.name=\"len\";this.message=a+\"-8192\"},ba=function(a,b,c){c=c||ua;if(2036>=b.length)wc(a,b,c);else if(8192>=b.length)x(a,b,c)||wd(a,b,c)||wc(a,b,c);else throw ge(\"len\",b.length),new Da(b.length);},wc=function(a,b,c){var d=ta(a+\"?\"+b);d.onload=d.onerror=function(){d.onload=null;d.onerror=null;c()}},wd=function(a,b,c){var d=O.XMLHttpRequest;if(!d)return!1;var e=new d;if(!(\"withCredentials\"in e))return!1;\ne.open(\"POST\",a,!0);e.withCredentials=!0;e.setRequestHeader(\"Content-Type\",\"text/plain\");e.onreadystatechange=function(){4==e.readyState&&(c(),e=null)};e.send(b);return!0},x=function(a,b,c){return O.navigator.sendBeacon?O.navigator.sendBeacon(a,b)?(c(),!0):!1:!1},ge=function(a,b,c){1<=100*Math.random()||Aa(\"?\")||(a=[\"t=error\",\"_e=\"+a,\"_v=j40\",\"sr=1\"],b&&a.push(\"_f=\"+b),c&&a.push(\"_m=\"+K(c.substring(0,100))),a.push(\"aip=1\"),a.push(\"z=\"+hd()),wc(oc()+\"/collect\",a.join(\"&\"),ua))};var Ha=function(){this.M=[]};Ha.prototype.add=function(a){this.M.push(a)};Ha.prototype.D=function(a){try{for(var b=0;b<this.M.length;b++){var c=a.get(this.M[b]);c&&ea(c)&&c.call(O,a)}}catch(d){}b=a.get(Ia);b!=ua&&ea(b)&&(a.set(Ia,ua,!0),setTimeout(b,10))};function Ja(a){if(100!=a.get(Ka)&&La(P(a,Q))%1E4>=100*R(a,Ka))throw\"abort\";}function Ma(a){if(Aa(P(a,Na)))throw\"abort\";}function Oa(){var a=M.location.protocol;if(\"http:\"!=a&&\"https:\"!=a)throw\"abort\";}\nfunction Pa(a){try{O.navigator.sendBeacon?J(42):O.XMLHttpRequest&&\"withCredentials\"in new O.XMLHttpRequest&&J(40)}catch(c){}a.set(ld,Td(a),!0);a.set(Ac,R(a,Ac)+1);var b=[];Qa.map(function(c,d){if(d.F){var e=a.get(c);void 0!=e&&e!=d.defaultValue&&(\"boolean\"==typeof e&&(e*=1),b.push(d.F+\"=\"+K(\"\"+e)))}});b.push(\"z=\"+Bd());a.set(Ra,b.join(\"&\"),!0)}\nfunction Sa(a){var b=P(a,gd)||oc()+\"/collect\",c=P(a,fa);!c&&a.get(Vd)&&(c=\"beacon\");if(c){var d=P(a,Ra),e=a.get(Ia),e=e||ua;\"image\"==c?wc(b,d,e):\"xhr\"==c&&wd(b,d,e)||\"beacon\"==c&&x(b,d,e)||ba(b,d,e)}else ba(b,P(a,Ra),a.get(Ia));a.set(Ia,ua,!0)}function Hc(a){var b=O.gaData;b&&(b.expId&&a.set(Nc,b.expId),b.expVar&&a.set(Oc,b.expVar))}function cd(){if(O.navigator&&\"preview\"==O.navigator.loadPurpose)throw\"abort\";}function yd(a){var b=O.gaDevIds;ka(b)&&0!=b.length&&a.set(\"&did\",b.join(\",\"),!0)}\nfunction vb(a){if(!a.get(Na))throw\"abort\";};var hd=function(){return Math.round(2147483647*Math.random())},Bd=function(){try{var a=new Uint32Array(1);O.crypto.getRandomValues(a);return a[0]&2147483647}catch(b){return hd()}};function Ta(a){var b=R(a,Ua);500<=b&&J(15);var c=P(a,Va);if(\"transaction\"!=c&&\"item\"!=c){var c=R(a,Wa),d=(new Date).getTime(),e=R(a,Xa);0==e&&a.set(Xa,d);e=Math.round(2*(d-e)/1E3);0<e&&(c=Math.min(c+e,20),a.set(Xa,d));if(0>=c)throw\"abort\";a.set(Wa,--c)}a.set(Ua,++b)};var Ya=function(){this.data=new ee},Qa=new ee,Za=[];Ya.prototype.get=function(a){var b=$a(a),c=this.data.get(a);b&&void 0==c&&(c=ea(b.defaultValue)?b.defaultValue():b.defaultValue);return b&&b.Z?b.Z(this,a,c):c};var P=function(a,b){var c=a.get(b);return void 0==c?\"\":\"\"+c},R=function(a,b){var c=a.get(b);return void 0==c||\"\"===c?0:1*c};Ya.prototype.set=function(a,b,c){if(a)if(\"object\"==typeof a)for(var d in a)a.hasOwnProperty(d)&&ab(this,d,a[d],c);else ab(this,a,b,c)};\nvar ab=function(a,b,c,d){if(void 0!=c)switch(b){case Na:wb.test(c)}var e=$a(b);e&&e.o?e.o(a,b,c,d):a.data.set(b,c,d)},bb=function(a,b,c,d,e){this.name=a;this.F=b;this.Z=d;this.o=e;this.defaultValue=c},$a=function(a){var b=Qa.get(a);if(!b)for(var c=0;c<Za.length;c++){var d=Za[c],e=d[0].exec(a);if(e){b=d[1](e);Qa.set(b.name,b);break}}return b},yc=function(a){var b;Qa.map(function(c,d){d.F==a&&(b=d)});return b&&b.name},S=function(a,b,c,d,e){a=new bb(a,b,c,d,e);Qa.set(a.name,a);return a.name},cb=function(a,\nb){Za.push([new RegExp(\"^\"+a+\"$\"),b])},T=function(a,b,c){return S(a,b,c,void 0,db)},db=function(){};var gb=qa(window.GoogleAnalyticsObject)&&sa(window.GoogleAnalyticsObject)||\"ga\",Ba=!1,he=S(\"_br\"),hb=T(\"apiVersion\",\"v\"),ib=T(\"clientVersion\",\"_v\");S(\"anonymizeIp\",\"aip\");var jb=S(\"adSenseId\",\"a\"),Va=S(\"hitType\",\"t\"),Ia=S(\"hitCallback\"),Ra=S(\"hitPayload\");S(\"nonInteraction\",\"ni\");S(\"currencyCode\",\"cu\");S(\"dataSource\",\"ds\");var Vd=S(\"useBeacon\",void 0,!1),fa=S(\"transport\");S(\"sessionControl\",\"sc\",\"\");S(\"sessionGroup\",\"sg\");S(\"queueTime\",\"qt\");var Ac=S(\"_s\",\"_s\");S(\"screenName\",\"cd\");\nvar kb=S(\"location\",\"dl\",\"\"),lb=S(\"referrer\",\"dr\"),mb=S(\"page\",\"dp\",\"\");S(\"hostname\",\"dh\");var nb=S(\"language\",\"ul\"),ob=S(\"encoding\",\"de\");S(\"title\",\"dt\",function(){return M.title||void 0});cb(\"contentGroup([0-9]+)\",function(a){return new bb(a[0],\"cg\"+a[1])});var pb=S(\"screenColors\",\"sd\"),qb=S(\"screenResolution\",\"sr\"),rb=S(\"viewportSize\",\"vp\"),sb=S(\"javaEnabled\",\"je\"),tb=S(\"flashVersion\",\"fl\");S(\"campaignId\",\"ci\");S(\"campaignName\",\"cn\");S(\"campaignSource\",\"cs\");S(\"campaignMedium\",\"cm\");\nS(\"campaignKeyword\",\"ck\");S(\"campaignContent\",\"cc\");var ub=S(\"eventCategory\",\"ec\"),xb=S(\"eventAction\",\"ea\"),yb=S(\"eventLabel\",\"el\"),zb=S(\"eventValue\",\"ev\"),Bb=S(\"socialNetwork\",\"sn\"),Cb=S(\"socialAction\",\"sa\"),Db=S(\"socialTarget\",\"st\"),Eb=S(\"l1\",\"plt\"),Fb=S(\"l2\",\"pdt\"),Gb=S(\"l3\",\"dns\"),Hb=S(\"l4\",\"rrt\"),Ib=S(\"l5\",\"srt\"),Jb=S(\"l6\",\"tcp\"),Kb=S(\"l7\",\"dit\"),Lb=S(\"l8\",\"clt\"),Mb=S(\"timingCategory\",\"utc\"),Nb=S(\"timingVar\",\"utv\"),Ob=S(\"timingLabel\",\"utl\"),Pb=S(\"timingValue\",\"utt\");S(\"appName\",\"an\");\nS(\"appVersion\",\"av\",\"\");S(\"appId\",\"aid\",\"\");S(\"appInstallerId\",\"aiid\",\"\");S(\"exDescription\",\"exd\");S(\"exFatal\",\"exf\");var Nc=S(\"expId\",\"xid\"),Oc=S(\"expVar\",\"xvar\"),Rc=S(\"_utma\",\"_utma\"),Sc=S(\"_utmz\",\"_utmz\"),Tc=S(\"_utmht\",\"_utmht\"),Ua=S(\"_hc\",void 0,0),Xa=S(\"_ti\",void 0,0),Wa=S(\"_to\",void 0,20);cb(\"dimension([0-9]+)\",function(a){return new bb(a[0],\"cd\"+a[1])});cb(\"metric([0-9]+)\",function(a){return new bb(a[0],\"cm\"+a[1])});S(\"linkerParam\",void 0,void 0,Bc,db);var ld=S(\"usage\",\"_u\"),Gd=S(\"_um\");\nS(\"forceSSL\",void 0,void 0,function(){return Ba},function(a,b,c){J(34);Ba=!!c});var ed=S(\"_j1\",\"jid\");cb(\"\\\\&(.*)\",function(a){var b=new bb(a[0],a[1]),c=yc(a[0].substring(1));c&&(b.Z=function(a){return a.get(c)},b.o=function(a,b,g,ca){a.set(c,g,ca)},b.F=void 0);return b});\nvar Qb=T(\"_oot\"),dd=S(\"previewTask\"),Rb=S(\"checkProtocolTask\"),md=S(\"validationTask\"),Sb=S(\"checkStorageTask\"),Uc=S(\"historyImportTask\"),Tb=S(\"samplerTask\"),Vb=S(\"_rlt\"),Wb=S(\"buildHitTask\"),Xb=S(\"sendHitTask\"),Vc=S(\"ceTask\"),zd=S(\"devIdTask\"),Cd=S(\"timingTask\"),Ld=S(\"displayFeaturesTask\"),V=T(\"name\"),Q=T(\"clientId\",\"cid\"),Ad=S(\"userId\",\"uid\"),Na=T(\"trackingId\",\"tid\"),U=T(\"cookieName\",void 0,\"_ga\"),W=T(\"cookieDomain\"),Yb=T(\"cookiePath\",void 0,\"/\"),Zb=T(\"cookieExpires\",void 0,63072E3),$b=T(\"legacyCookieDomain\"),\nWc=T(\"legacyHistoryImport\",void 0,!0),ac=T(\"storage\",void 0,\"cookie\"),bc=T(\"allowLinker\",void 0,!1),cc=T(\"allowAnchor\",void 0,!0),Ka=T(\"sampleRate\",\"sf\",100),dc=T(\"siteSpeedSampleRate\",void 0,1),ec=T(\"alwaysSendReferrer\",void 0,!1),gd=S(\"transportUrl\"),Md=S(\"_r\",\"_r\");function X(a,b,c,d){b[a]=function(){try{return d&&J(d),c.apply(this,arguments)}catch(b){throw ge(\"exc\",a,b&&b.name),b;}}};var Od=function(a,b,c){this.V=1E4;this.fa=a;this.$=!1;this.B=b;this.ea=c||1},Ed=function(a,b){var c;if(a.fa&&a.$)return 0;a.$=!0;if(b){if(a.B&&R(b,a.B))return R(b,a.B);if(0==b.get(dc))return 0}if(0==a.V)return 0;void 0===c&&(c=Bd());return 0==c%a.V?Math.floor(c/a.V)%a.ea+1:0};var ie=new Od(!0,he,7),je=function(a){if(!Ud()&&!Ba){var b=Ed(ie,a);if(b&&!(!O.navigator.sendBeacon&&4<=b&&6>=b)){var c=(new Date).getHours(),d=[Bd(),Bd(),Bd()].join(\".\");a=(3==b||5==b?\"https:\":\"http:\")+\"//www.google-analytics.com/collect?z=br.\";a+=[b,\"A\",c,d].join(\".\");var e=1!=b%3?\"https:\":\"http:\",e=e+\"//www.google-analytics.com/collect?z=br.\",e=e+[b,\"B\",c,d].join(\".\");7==b&&(e=e.replace(\"//www.\",\"//ssl.\"));c=function(){4<=b&&6>=b?O.navigator.sendBeacon(e,\"\"):ta(e)};Bd()%2?(ta(a),c()):(c(),ta(a))}}};function fc(){var a,b,c;if((c=(c=O.navigator)?c.plugins:null)&&c.length)for(var d=0;d<c.length&&!b;d++){var e=c[d];-1<e.name.indexOf(\"Shockwave Flash\")&&(b=e.description)}if(!b)try{a=new ActiveXObject(\"ShockwaveFlash.ShockwaveFlash.7\"),b=a.GetVariable(\"$version\")}catch(g){}if(!b)try{a=new ActiveXObject(\"ShockwaveFlash.ShockwaveFlash.6\"),b=\"WIN 6,0,21,0\",a.AllowScriptAccess=\"always\",b=a.GetVariable(\"$version\")}catch(g){}if(!b)try{a=new ActiveXObject(\"ShockwaveFlash.ShockwaveFlash\"),b=a.GetVariable(\"$version\")}catch(g){}b&&\n(a=b.match(/[\\d]+/g))&&3<=a.length&&(b=a[0]+\".\"+a[1]+\" r\"+a[2]);return b||void 0};var gc=function(a,b){var c=Math.min(R(a,dc),100);if(!(La(P(a,Q))%100>=c)&&(c={},Ec(c)||Fc(c))){var d=c[Eb];void 0==d||Infinity==d||isNaN(d)||(0<d?(Y(c,Gb),Y(c,Jb),Y(c,Ib),Y(c,Fb),Y(c,Hb),Y(c,Kb),Y(c,Lb),b(c)):L(O,\"load\",function(){gc(a,b)},!1))}},Ec=function(a){var b=O.performance||O.webkitPerformance,b=b&&b.timing;if(!b)return!1;var c=b.navigationStart;if(0==c)return!1;a[Eb]=b.loadEventStart-c;a[Gb]=b.domainLookupEnd-b.domainLookupStart;a[Jb]=b.connectEnd-b.connectStart;a[Ib]=b.responseStart-b.requestStart;\na[Fb]=b.responseEnd-b.responseStart;a[Hb]=b.fetchStart-c;a[Kb]=b.domInteractive-c;a[Lb]=b.domContentLoadedEventStart-c;return!0},Fc=function(a){if(O.top!=O)return!1;var b=O.external,c=b&&b.onloadT;b&&!b.isValidLoadTime&&(c=void 0);2147483648<c&&(c=void 0);0<c&&b.setPageReadyTime();if(void 0==c)return!1;a[Eb]=c;return!0},Y=function(a,b){var c=a[b];if(isNaN(c)||Infinity==c||0>c)a[b]=void 0},Fd=function(a){return function(b){\"pageview\"!=b.get(Va)||a.I||(a.I=!0,gc(b,function(b){a.send(\"timing\",b)}))}};var hc=!1,mc=function(a){if(\"cookie\"==P(a,ac)){var b=P(a,U),c=nd(a),d=kc(P(a,Yb)),e=lc(P(a,W)),g=1E3*R(a,Zb),ca=P(a,Na);if(\"auto\"!=e)zc(b,c,d,e,ca,g)&&(hc=!0);else{J(32);var l;a:{c=[];e=xa().split(\".\");if(4==e.length&&(l=e[e.length-1],parseInt(l,10)==l)){l=[\"none\"];break a}for(l=e.length-2;0<=l;l--)c.push(e.slice(l).join(\".\"));c.push(\"none\");l=c}for(var k=0;k<l.length;k++)if(e=l[k],a.data.set(W,e),c=nd(a),zc(b,c,d,e,ca,g)){hc=!0;return}a.data.set(W,\"auto\")}}},nc=function(a){if(\"cookie\"==P(a,ac)&&\n!hc&&(mc(a),!hc))throw\"abort\";},Yc=function(a){if(a.get(Wc)){var b=P(a,W),c=P(a,$b)||xa(),d=Xc(\"__utma\",c,b);d&&(J(19),a.set(Tc,(new Date).getTime(),!0),a.set(Rc,d.R),(b=Xc(\"__utmz\",c,b))&&d.hash==b.hash&&a.set(Sc,b.R))}},nd=function(a){var b=Cc(P(a,Q)),c=ic(P(a,W));a=jc(P(a,Yb));1<a&&(c+=\"-\"+a);return[\"GA1\",c,b].join(\".\")},Gc=function(a,b,c){for(var d=[],e=[],g,ca=0;ca<a.length;ca++){var l=a[ca];l.H[c]==b?d.push(l):void 0==g||l.H[c]<g?(e=[l],g=l.H[c]):l.H[c]==g&&e.push(l)}return 0<d.length?d:e},\nlc=function(a){return 0==a.indexOf(\".\")?a.substr(1):a},ic=function(a){return lc(a).split(\".\").length},kc=function(a){if(!a)return\"/\";1<a.length&&a.lastIndexOf(\"/\")==a.length-1&&(a=a.substr(0,a.length-1));0!=a.indexOf(\"/\")&&(a=\"/\"+a);return a},jc=function(a){a=kc(a);return\"/\"==a?1:a.split(\"/\").length};function Xc(a,b,c){\"none\"==b&&(b=\"\");var d=[],e=Ca(a);a=\"__utma\"==a?6:2;for(var g=0;g<e.length;g++){var ca=(\"\"+e[g]).split(\".\");ca.length>=a&&d.push({hash:ca[0],R:e[g],O:ca})}return 0==d.length?void 0:1==d.length?d[0]:Zc(b,d)||Zc(c,d)||Zc(null,d)||d[0]}function Zc(a,b){var c,d;null==a?c=d=1:(c=La(a),d=La(D(a,\".\")?a.substring(1):\".\"+a));for(var e=0;e<b.length;e++)if(b[e].hash==c||b[e].hash==d)return b[e]};var od=new RegExp(/^https?:\\/\\/([^\\/:]+)/),pd=/(.*)([?&#])(?:_ga=[^&#]*)(?:&?)(.*)/;function Bc(a){a=a.get(Q);var b=Ic(a,0);return\"_ga=1.\"+K(b+\".\"+a)}function Ic(a,b){for(var c=new Date,d=O.navigator,e=d.plugins||[],c=[a,d.userAgent,c.getTimezoneOffset(),c.getYear(),c.getDate(),c.getHours(),c.getMinutes()+b],d=0;d<e.length;++d)c.push(e[d].description);return La(c.join(\".\"))}var Dc=function(a){J(48);this.target=a;this.T=!1};\nDc.prototype.ca=function(a,b){if(a.tagName){if(\"a\"==a.tagName.toLowerCase()){a.href&&(a.href=qd(this,a.href,b));return}if(\"form\"==a.tagName.toLowerCase())return rd(this,a)}if(\"string\"==typeof a)return qd(this,a,b)};\nvar qd=function(a,b,c){var d=pd.exec(b);d&&3<=d.length&&(b=d[1]+(d[3]?d[2]+d[3]:\"\"));a=a.target.get(\"linkerParam\");var e=b.indexOf(\"?\"),d=b.indexOf(\"#\");c?b+=(-1==d?\"#\":\"&\")+a:(c=-1==e?\"?\":\"&\",b=-1==d?b+(c+a):b.substring(0,d)+c+a+b.substring(d));return b=b.replace(/&+_ga=/,\"&_ga=\")},rd=function(a,b){if(b&&b.action){var c=a.target.get(\"linkerParam\").split(\"=\")[1];if(\"get\"==b.method.toLowerCase()){for(var d=b.childNodes||[],e=0;e<d.length;e++)if(\"_ga\"==d[e].name){d[e].setAttribute(\"value\",c);return}d=\nM.createElement(\"input\");d.setAttribute(\"type\",\"hidden\");d.setAttribute(\"name\",\"_ga\");d.setAttribute(\"value\",c);b.appendChild(d)}else\"post\"==b.method.toLowerCase()&&(b.action=qd(a,b.action))}};\nDc.prototype.S=function(a,b,c){function d(c){try{c=c||O.event;var d;a:{var g=c.target||c.srcElement;for(c=100;g&&0<c;){if(g.href&&g.nodeName.match(/^a(?:rea)?$/i)){d=g;break a}g=g.parentNode;c--}d={}}(\"http:\"==d.protocol||\"https:\"==d.protocol)&&sd(a,d.hostname||\"\")&&d.href&&(d.href=qd(e,d.href,b))}catch(w){J(26)}}var e=this;this.T||(this.T=!0,L(M,\"mousedown\",d,!1),L(M,\"keyup\",d,!1));if(c){c=function(b){b=b||O.event;if((b=b.target||b.srcElement)&&b.action){var c=b.action.match(od);c&&sd(a,c[1])&&rd(e,\nb)}};for(var g=0;g<M.forms.length;g++)L(M.forms[g],\"submit\",c)}};function sd(a,b){if(b==M.location.hostname)return!1;for(var c=0;c<a.length;c++)if(a[c]instanceof RegExp){if(a[c].test(b))return!0}else if(0<=b.indexOf(a[c]))return!0;return!1};var Jd=function(a,b,c){this.U=ed;this.aa=b;(b=c)||(b=(b=P(a,V))&&\"t0\"!=b?Wd.test(b)?\"_gat_\"+Cc(P(a,Na)):\"_gat_\"+Cc(b):\"_gat\");this.Y=b},Rd=function(a,b){var c=b.get(Wb);b.set(Wb,function(b){Pd(a,b);var d=c(b);Qd(a,b);return d});var d=b.get(Xb);b.set(Xb,function(b){var c=d(b);Id(a,b);return c})},Pd=function(a,b){b.get(a.U)||(\"1\"==Ca(a.Y)[0]?b.set(a.U,\"\",!0):b.set(a.U,\"\"+hd(),!0))},Qd=function(a,b){b.get(a.U)&&zc(a.Y,\"1\",b.get(Yb),b.get(W),b.get(Na),6E5)},Id=function(a,b){if(b.get(a.U)){var c=new ee,\nd=function(a){$a(a).F&&c.set($a(a).F,b.get(a))};d(hb);d(ib);d(Na);d(Q);d(a.U);c.set($a(ld).F,Td(b));var e=a.aa;c.map(function(a,b){e+=K(a)+\"=\";e+=K(\"\"+b)+\"&\"});e+=\"z=\"+hd();ta(e);b.set(a.U,\"\",!0)}},Wd=/^gtm\\d+$/;var fd=function(a,b){var c=a.b;if(!c.get(\"dcLoaded\")){Nd(c,29);b=b||{};var d;b[U]&&(d=Cc(b[U]));d=new Jd(c,\"https://stats.g.doubleclick.net/r/collect?t=dc&aip=1&_r=3&\",d);Rd(d,c);c.set(\"dcLoaded\",!0)}};var Sd=function(a){if(!a.get(\"dcLoaded\")&&\"cookie\"==a.get(ac)){Nd(a,51);var b=new Jd(a);Pd(b,a);Qd(b,a);a.get(b.U)&&(a.set(Md,1,!0),a.set(gd,oc()+\"/r/collect\",!0))}};var Lc=function(){var a=O.gaGlobal=O.gaGlobal||{};return a.hid=a.hid||hd()};var ad,bd=function(a,b,c){if(!ad){var d;d=M.location.hash;var e=O.name,g=/^#?gaso=([^&]*)/;if(e=(d=(d=d&&d.match(g)||e&&e.match(g))?d[1]:Ca(\"GASO\")[0]||\"\")&&d.match(/^(?:!([-0-9a-z.]{1,40})!)?([-.\\w]{10,1200})$/i))zc(\"GASO\",\"\"+d,c,b,a,0),window._udo||(window._udo=b),window._utcp||(window._utcp=c),a=e[1],wa(\"https://www.google.com/analytics/web/inpage/pub/inpage.js?\"+(a?\"prefix=\"+a+\"&\":\"\")+hd(),\"_gasojs\");ad=!0}};var wb=/^(UA|YT|MO|GP)-(\\d+)-(\\d+)$/,pc=function(a){function b(a,b){d.b.data.set(a,b)}function c(a,c){b(a,c);d.filters.add(a)}var d=this;this.b=new Ya;this.filters=new Ha;b(V,a[V]);b(Na,sa(a[Na]));b(U,a[U]);b(W,a[W]||xa());b(Yb,a[Yb]);b(Zb,a[Zb]);b($b,a[$b]);b(Wc,a[Wc]);b(bc,a[bc]);b(cc,a[cc]);b(Ka,a[Ka]);b(dc,a[dc]);b(ec,a[ec]);b(ac,a[ac]);b(Ad,a[Ad]);b(hb,1);b(ib,\"j40\");c(Qb,Ma);c(dd,cd);c(Rb,Oa);c(md,vb);c(Sb,nc);c(Uc,Yc);c(Tb,Ja);c(Vb,Ta);c(Vc,Hc);c(zd,yd);c(Ld,Sd);c(Wb,Pa);c(Xb,Sa);c(Cd,Fd(this));\nJc(this.b,a[Q]);Kc(this.b);this.b.set(jb,Lc());bd(this.b.get(Na),this.b.get(W),this.b.get(Yb))},Jc=function(a,b){if(\"cookie\"==P(a,ac)){hc=!1;var c;b:{var d=Ca(P(a,U));if(d&&!(1>d.length)){c=[];for(var e=0;e<d.length;e++){var g;g=d[e].split(\".\");var ca=g.shift();(\"GA1\"==ca||\"1\"==ca)&&1<g.length?(ca=g.shift().split(\"-\"),1==ca.length&&(ca[1]=\"1\"),ca[0]*=1,ca[1]*=1,g={H:ca,s:g.join(\".\")}):g=void 0;g&&c.push(g)}if(1==c.length){J(13);c=c[0].s;break b}if(0==c.length)J(12);else{J(14);d=ic(P(a,W));c=Gc(c,\nd,0);if(1==c.length){c=c[0].s;break b}d=jc(P(a,Yb));c=Gc(c,d,1);c=c[0]&&c[0].s;break b}}c=void 0}c||(c=P(a,W),d=P(a,$b)||xa(),c=Xc(\"__utma\",d,c),void 0!=c?(J(10),c=c.O[1]+\".\"+c.O[2]):c=void 0);c&&(a.data.set(Q,c),hc=!0)}c=a.get(cc);if(e=(c=M.location[c?\"href\":\"search\"].match(\"(?:&|#|\\\\?)\"+K(\"_ga\").replace(/([.*+?^=!:${}()|\\[\\]\\/\\\\])/g,\"\\\\$1\")+\"=([^&#]*)\"))&&2==c.length?c[1]:\"\")a.get(bc)?(c=e.indexOf(\".\"),-1==c?J(22):(d=e.substring(c+1),\"1\"!=e.substring(0,c)?J(22):(c=d.indexOf(\".\"),-1==c?J(22):(e=\nd.substring(0,c),c=d.substring(c+1),e!=Ic(c,0)&&e!=Ic(c,-1)&&e!=Ic(c,-2)?J(23):(J(11),a.data.set(Q,c)))))):J(21);b&&(J(9),a.data.set(Q,K(b)));if(!a.get(Q))if(c=(c=O.gaGlobal&&O.gaGlobal.vid)&&-1!=c.search(/^(?:utma\\.)?\\d+\\.\\d+$/)?c:void 0)J(17),a.data.set(Q,c);else{J(8);c=O.navigator.userAgent+(M.cookie?M.cookie:\"\")+(M.referrer?M.referrer:\"\");d=c.length;for(e=O.history.length;0<e;)c+=e--^d++;a.data.set(Q,[hd()^La(c)&2147483647,Math.round((new Date).getTime()/1E3)].join(\".\"))}mc(a)},Kc=function(a){var b=\nO.navigator,c=O.screen,d=M.location;a.set(lb,ya(a.get(ec)));if(d){var e=d.pathname||\"\";\"/\"!=e.charAt(0)&&(J(31),e=\"/\"+e);a.set(kb,d.protocol+\"//\"+d.hostname+e+d.search)}c&&a.set(qb,c.width+\"x\"+c.height);c&&a.set(pb,c.colorDepth+\"-bit\");var c=M.documentElement,g=(e=M.body)&&e.clientWidth&&e.clientHeight,ca=[];c&&c.clientWidth&&c.clientHeight&&(\"CSS1Compat\"===M.compatMode||!g)?ca=[c.clientWidth,c.clientHeight]:g&&(ca=[e.clientWidth,e.clientHeight]);c=0>=ca[0]||0>=ca[1]?\"\":ca.join(\"x\");a.set(rb,c);a.set(tb,\nfc());a.set(ob,M.characterSet||M.charset);a.set(sb,b&&\"function\"===typeof b.javaEnabled&&b.javaEnabled()||!1);a.set(nb,(b&&(b.language||b.browserLanguage)||\"\").toLowerCase());if(d&&a.get(cc)&&(b=M.location.hash)){b=b.split(/[?&#]+/);d=[];for(c=0;c<b.length;++c)(D(b[c],\"utm_id\")||D(b[c],\"utm_campaign\")||D(b[c],\"utm_source\")||D(b[c],\"utm_medium\")||D(b[c],\"utm_term\")||D(b[c],\"utm_content\")||D(b[c],\"gclid\")||D(b[c],\"dclid\")||D(b[c],\"gclsrc\"))&&d.push(b[c]);0<d.length&&(b=\"#\"+d.join(\"&\"),a.set(kb,a.get(kb)+\nb))}};pc.prototype.get=function(a){return this.b.get(a)};pc.prototype.set=function(a,b){this.b.set(a,b)};var qc={pageview:[mb],event:[ub,xb,yb,zb],social:[Bb,Cb,Db],timing:[Mb,Nb,Pb,Ob]};pc.prototype.send=function(a){if(!(1>arguments.length)){var b,c;\"string\"===typeof arguments[0]?(b=arguments[0],c=[].slice.call(arguments,1)):(b=arguments[0]&&arguments[0][Va],c=arguments);b&&(c=za(qc[b]||[],c),c[Va]=b,this.b.set(c,void 0,!0),this.filters.D(this.b),this.b.data.m={},je(this.b))}};var rc=function(a){if(\"prerender\"==M.visibilityState)return!1;a();return!0};var td=/^(?:(\\w+)\\.)?(?:(\\w+):)?(\\w+)$/,sc=function(a){if(ea(a[0]))this.u=a[0];else{var b=td.exec(a[0]);null!=b&&4==b.length&&(this.c=b[1]||\"t0\",this.K=b[2]||\"\",this.C=b[3],this.a=[].slice.call(a,1),this.K||(this.A=\"create\"==this.C,this.i=\"require\"==this.C,this.g=\"provide\"==this.C,this.ba=\"remove\"==this.C),this.i&&(3<=this.a.length?(this.X=this.a[1],this.W=this.a[2]):this.a[1]&&(qa(this.a[1])?this.X=this.a[1]:this.W=this.a[1])));b=a[1];a=a[2];if(!this.C)throw\"abort\";if(this.i&&(!qa(b)||\"\"==b))throw\"abort\";\nif(this.g&&(!qa(b)||\"\"==b||!ea(a)))throw\"abort\";if(ud(this.c)||ud(this.K))throw\"abort\";if(this.g&&\"t0\"!=this.c)throw\"abort\";}};function ud(a){return 0<=a.indexOf(\".\")||0<=a.indexOf(\":\")};var Yd,Zd,$d;Yd=new ee;$d=new ee;Zd={ec:45,ecommerce:46,linkid:47};\nvar ae=function(a){function b(a){var b=(a.hostname||\"\").split(\":\")[0].toLowerCase(),c=(a.protocol||\"\").toLowerCase(),c=1*a.port||(\"http:\"==c?80:\"https:\"==c?443:\"\");a=a.pathname||\"\";D(a,\"/\")||(a=\"/\"+a);return[b,\"\"+c,a]}var c=M.createElement(\"a\");c.href=M.location.href;var d=(c.protocol||\"\").toLowerCase(),e=b(c),g=c.search||\"\",ca=d+\"//\"+e[0]+(e[1]?\":\"+e[1]:\"\");D(a,\"//\")?a=d+a:D(a,\"/\")?a=ca+a:!a||D(a,\"?\")?a=ca+e[2]+(a||g):0>a.split(\"/\")[0].indexOf(\":\")&&(a=ca+e[2].substring(0,e[2].lastIndexOf(\"/\"))+\n\"/\"+a);c.href=a;d=b(c);return{protocol:(c.protocol||\"\").toLowerCase(),host:d[0],port:d[1],path:d[2],G:c.search||\"\",url:a||\"\"}};var Z={ga:function(){Z.f=[]}};Z.ga();Z.D=function(a){var b=Z.J.apply(Z,arguments),b=Z.f.concat(b);for(Z.f=[];0<b.length&&!Z.v(b[0])&&!(b.shift(),0<Z.f.length););Z.f=Z.f.concat(b)};\nZ.J=function(a){for(var b=[],c=0;c<arguments.length;c++)try{var d=new sc(arguments[c]);if(d.g)Yd.set(d.a[0],d.a[1]);else{if(d.i){var e=d,g=e.a[0];if(!ea(Yd.get(g))&&!$d.get(g)){Zd.hasOwnProperty(g)&&J(Zd[g]);var ca=e.X;!ca&&Zd.hasOwnProperty(g)?(J(39),ca=g+\".js\"):J(43);if(ca){ca&&0<=ca.indexOf(\"/\")||(ca=(Ba||Ud()?\"https:\":\"http:\")+\"//www.google-analytics.com/plugins/ua/\"+ca);var l=ae(ca),e=void 0;var k=l.protocol,w=M.location.protocol,e=\"https:\"==k||k==w?!0:\"http:\"!=k?!1:\"http:\"==w;var Xd;if(Xd=e){var e=\nl,be=ae(M.location.href);if(e.G||0<=e.url.indexOf(\"?\")||0<=e.path.indexOf(\"://\"))Xd=!1;else if(e.host==be.host&&e.port==be.port)Xd=!0;else{var ce=\"http:\"==e.protocol?80:443;Xd=\"www.google-analytics.com\"==e.host&&(e.port||ce)==ce&&D(e.path,\"/plugins/\")?!0:!1}}Xd&&(wa(l.url),$d.set(g,!0))}}}b.push(d)}}catch(de){}return b};\nZ.v=function(a){try{if(a.u)a.u.call(O,N.j(\"t0\"));else{var b=a.c==gb?N:N.j(a.c);if(a.A)\"t0\"==a.c&&N.create.apply(N,a.a);else if(a.ba)N.remove(a.c);else if(b)if(a.i){var c;var d=a.a[0],e=a.W;b==N||b.get(V);var g=Yd.get(d);ea(g)?(b.plugins_=b.plugins_||new ee,b.plugins_.get(d)||b.plugins_.set(d,new g(b,e||{})),c=!0):c=!1;if(!c)return!0}else if(a.K){var ca=a.C,l=a.a,k=b.plugins_.get(a.K);k[ca].apply(k,l)}else b[a.C].apply(b,a.a)}}catch(w){}};var N=function(a){J(1);Z.D.apply(Z,[arguments])};N.h={};N.P=[];N.L=0;N.answer=42;var uc=[Na,W,V];N.create=function(a){var b=za(uc,[].slice.call(arguments));b[V]||(b[V]=\"t0\");var c=\"\"+b[V];if(N.h[c])return N.h[c];b=new pc(b);N.h[c]=b;N.P.push(b);return b};N.remove=function(a){for(var b=0;b<N.P.length;b++)if(N.P[b].get(V)==a){N.P.splice(b,1);N.h[a]=null;break}};N.j=function(a){return N.h[a]};N.getAll=function(){return N.P.slice(0)};\nN.N=function(){\"ga\"!=gb&&J(49);var a=O[gb];if(!a||42!=a.answer){N.L=a&&a.l;N.loaded=!0;var b=O[gb]=N;X(\"create\",b,b.create);X(\"remove\",b,b.remove);X(\"getByName\",b,b.j,5);X(\"getAll\",b,b.getAll,6);b=pc.prototype;X(\"get\",b,b.get,7);X(\"set\",b,b.set,4);X(\"send\",b,b.send);b=Ya.prototype;X(\"get\",b,b.get);X(\"set\",b,b.set);if(!Ud()&&!Ba){a:{for(var b=M.getElementsByTagName(\"script\"),c=0;c<b.length&&100>c;c++){var d=b[c].src;if(d&&0==d.indexOf(\"https://www.google-analytics.com/analytics\")){J(33);b=!0;break a}}b=\n!1}b&&(Ba=!0)}Ud()||Ba||!Ed(new Od)||(J(36),Ba=!0);(O.gaplugins=O.gaplugins||{}).Linker=Dc;b=Dc.prototype;Yd.set(\"linker\",Dc);X(\"decorate\",b,b.ca,20);X(\"autoLink\",b,b.S,25);Yd.set(\"displayfeatures\",fd);Yd.set(\"adfeatures\",fd);a=a&&a.q;ka(a)?Z.D.apply(N,a):J(50)}};N.da=function(){for(var a=N.getAll(),b=0;b<a.length;b++)a[b].get(V)};\n(function(){var a=N.N;if(!rc(a)){J(16);var b=!1,c=function(){if(!b&&rc(a)){b=!0;var d=c,e=M;e.removeEventListener?e.removeEventListener(\"visibilitychange\",d,!1):e.detachEvent&&e.detachEvent(\"onvisibilitychange\",d)}};L(M,\"visibilitychange\",c)}})();function La(a){var b=1,c=0,d;if(a)for(b=0,d=a.length-1;0<=d;d--)c=a.charCodeAt(d),b=(b<<6&268435455)+c+(c<<14),c=b&266338304,b=0!=c?b^c>>21:b;return b};})(window);\n"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 10964
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.486999982967973,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.15300000086426702,
+          "wait": 4.01800000690855,
+          "receive": 2.287999988766388,
+          "ssl": -1
+        },
+        "connection": "1043854",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.321Z",
+        "time": 118.26399998972192,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/bg_cat.png",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/bg_cat.png"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "content-length",
+              "value": "11820"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "2.229ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"2e2c-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/png"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 11820,
+            "mimeType": "image/png",
+            "text": "iVBORw0KGgoAAAANSUhEUgAAAf0AAAIYBAMAAACVgygXAAAALVBMVEUAAAAFBwj///8FBwgFBwgFBwgFBwgFBwgFBwgFBwgFBwgFBwgFBwgFBwgFBwgLjSB9AAAAD3RSTlMADQAHAgsMAQMKBQgECQbMWMMYAAAtn0lEQVR4XtzXQUsCQRiA4TkIK+HlI3bBgxD9ha1kw2DAUxHB3lIpWDqFlwUv0SEEg5aoYInEDQKhgiI6RCoUEULHjkFQ14KM/kTQIRxmkHV2kJl974rP8I0zg0Zbcs+0gjr8FwRmzkM8TQppYoT2jdM7G5gVbi9wzP2Lcz4M7CSHY+tP/vgQolIvlv6lNoRNf8Rx89fqMFSH1Tj58z4M3WE1Lv6FV+DJeMdx8CemgTd9Sn3/sw0RKnXV9qc6EC3jQWV/3oHIlbG0fv6drwem6XnbfwTN82qmdcTxLyC3f8wHZusvPebR5n28OcDs2FXQz579wuwOGtCuZbP3gHL+S+a9NsSd5qANdOmmWn6NsfVXeqHfSfQQGFmV/IkbClA6G+bzT/QKtNTxJ30OPZl2Ra1AQxE/zU9/8szQN3UMqOEfs4HIuHcRV5sdICvK76f55S7i7tmhFkB2f4rkGw9C3w9Fqf303s80UcSugWhZbn+C5K9iFLktcqAasvrpc99oiflScg+05PVrM9CX/oXEpJ1Df1lp/cTvzFSRsPaJsWpK6p9nPtnEPybTWEp/Bfpac5HQKv3H6rgr2v/L3bW+xnFleYWudrVbsplLd7Xdev0N3XTGj8QxJbISzmODChsUJUtIY4M3jw1tjMRMZhJa2LPb65k1bpzspO3N0sJ5zDIE1MTZMMOwSJgkXoYFibCbzbAMEjPJeBnmf1hb9tGq7rnPqtu3quf3yZbU1XXuPfc8H5erzlotP4rifw6Rb9SselX1Uydarchi98bXQNH8u7U7stPsbCAzpY8L8JaMgNaNxzo7r//le/rU/4lQ8K4/clFAwLeI/H4uQGlT8OqXHn2bIA/MSOzOu36sKZN9mHzzCwAyEOMnNUQ7vFSkb8Iof3kHf/f++i7RN2Qe+FteYxz2G18TPp6LbMVizNcuog9gyW8e5+s8EeBcYEdOkcxQwedEjtJ1iOSGPzDmD/URT7HMIPcnj0qy6/ABNeSJIspX7x+FN3b9iK8nTNtYE41tpv9dhyhiVJH+ZaKB+dptJ1BaY+M29rO5W8D0alB7OSdG0u7wUL/hVklkFJXoz+7e3Q7irsgixnyIQY5yp7OLQzwl0QwL/PwR/8E3tm7V4DE8YJ1kQQsK8NL12m3QUSd28ikVFQa7/3iPtphyl8Gs4mHCH7KCN4gYndpt6k2cb8g2zqpIf4GB6VwSaJrS6pAlfC4Sx2yH5wNyD5PKx/8UIkBqaXw1ZAvuhsQyxbivozwF+s9t76UvdisZVvbLQ/YwUkfM9y6YYxwskntQOKFraqaC26qBfwwOiUV8P1xLcuei4rHuKor/FxWj/Zdqv3gbRKtVbN0/7VePK8dnAsW33A5hrwy5R/+REO/dRxQe/71WrQaa3xacr1U2/b6BXOt8efjBvl6RU9N+sE6vt+8frN/6Q4ML5+cBhOO2dOi/p8qcQ6j+atDw+Db1pW0ClnTob4Z8jWsDSTzU33ndIW36H1g/f49iJwOE3EbII1/TO/8DvwC5doh8NfkHf7cOBPwI5Z3TDOwmes2QXqso0j9LGc6mrVtbYYJSF/G1ECAnDlAPAu9mYPA5iscQ0GsSTJG7GKcYCcJtg4I3CO3F5cD+V/L/Cox4w6kBkn11lInIbDOxAgH7kKP4BAofphsQwvJ8elsnVMJLwCgoIjY2YNxfQcdaJf7hEDCAdgAB7p8OiOoLGCp7WTkAHIACRAvqDYYInGHJ6w2gSooqY6W2BkgE5uuMgIRL7rv1CliCk4IFamkQfOFlVolIHtS/HHtYkcJpso0zA7D9IPuxVi8pPWCYZSm4bWCAwdj+OWTVKSuwHDOeNzwgDJBnq+oqWLXaCgDQGwwVsMwWdIEkqitfqzwBxkr/9hcQTyuJf3xW8MqWB0H3d6UyTZ4Ba3AYYCXVpl+dnb1ZRDpN6gFschhgNM30L3ActWV0KqQewCyvLqiZYvoDzg61ZdY/tpWLPNl6Nq3EwzGviHdUjmWOsZAhcIwsI/aL68Uv9vCMxR6sbzrhgIBmE9RQZiPecu0lYBqkCXIpv6YXvnEIJ1fgBrCQ6QNIuTmeQDuoKUaLXPPiSjrJz/A8NFdL/EG4o8DVr5PppH8JOSjIoFHEOd5B6qXXC4bCvXWeQevr6tEmywJK7wHYR3jMOSWLfau6SzMpygQ4l2pfd9qEkJc617cLHqcIjzl72lorgCRgGEFaEgEnUB3m/PEfE56HXgfnXy+BMooFbCpiAO4tUbsDltt5fattiunqLwGHJV3SJEaTKRh8fVniI+snefvvQkBkOMvWZvphpE3E/tqcZH+eHJb0W7phCxAZs4j97ft/eB6IHKsyYa5YBVpksv+ZhOvZ5HitIfcK9WOgmWSVP+5Jfend2n106N+MNdF7a5bvZLGjtwSnyzpwBzzxvgzNynYuHw3/uovyeXrAERM3SEr54wkIJ38mGxxXOiyOferHQDMkyfDnUyqTgX/4XbQAKJqpBhwxBfO6kDT5z38hHzUMC6Af++RzTTtB9j+Ph4HKVWSpwjrJUWOg+QTZP7ND02lfbiL1wkIQJHlMAbiYHPvnAqDof/TGBZV9/dgnwKGCKVXb7I8ni5Qe1pUWhQay5CLGQB1kWlrDt8DOH+rPSXgVxT4jCsC9iRk/02gErM4Aj68g9hkzmbCUlO2fQYMVtBag9BlK5keKgQYJub5OG2R55C5xLP70Y6D5pFzfz9FcCW0ZoB+xwW7zAiGQQrKKH8SYK/GXZAezkVtMJ0Pab916JXPkuRLQu4SPrX4SCFIrxE+G+1+O0waA31s/BppJxvjbD503MdmnHC3WCAIQjF/rlS+9uJ1XmVj5mmCH5moika+F+F0X06hmL0oSyK0nof3cIH6y3e3hE6SfBMqQJCr/Zkwkm/L16G7bXhCAi6BFLZdyyrm/dRcXxSdAu2wb5w2rSYQ+ZiQqx7m1c49i+eoRXzwrBhggShIIjn85ie3vqt6md/U9ng7QZABcN5BJwvidEfmbz7BuVHvlPXFDiDagbiQLRS/Wt9/ztfJgJ312M6wWA+C6oeUEjv8Mf9MeDzSuisLP0s+CB/a1v4P2DEU32bgmfpgcuG7w2QS0/wJvyxxZAcDpBk8HrkcUgJ597e8GsGN4pokMYz7ncWMRKyoTSHsPc7Y/16bm/LXu2UAw85i/AAs4CKo7CrNkvX/fa4hmjL90zA8ZQ200Hh5JgPFoDrh9338Etp87+nQCz/O+0BZMoJ6J5ko4ZAcHbCs/vP0fiC/VcT+qc26JAQbQV4EbBLBiW/qd4Y4+HuMFRF7fed1PUQdEtOzNGgH4tqWfzwvov8BX5M4h3izSfDQJuAfI92x3MY3yxv6+ozQeeqwhKGjTzz6RUdu2XwWFgiXkUxPLTrGCGV4jqgB80R79WZaznZGSD/iMba+4QSQpBlxXsaz859DbK49h+4Ad9J2JZAIsWxd/Duv7pjWulnDZpRr5KHUwEPrzLLP/JHPeb9lXT3vg4MFGFCdo2J74E8wpXNZLhGSYxQoLUQ5Azrb15zDYNK+bBZ1mJc1zUTRA3nbidy/sEspjFrTTHqOMx1QiNZWt2jV+1hlnsNTU37YulixFzSS4ZefXDTD7VyPM3pphMIATIYq/bLnhLYNfO49SeOo6oIkXcjWCAzhu1/W9Ip3oI8cCQwUsaMfxXNvWbw8ZP05EDuzhkMeItiofsen8A7EF1kQfIzHEtq4JOGxT/MP3ncWW/2hUVprACa2KfgDUDvHwgptYAVeMDIOB5VXHlOWq3x7yNarR9U8biW6nrhnJ3bJr/Tvo23Ix5M8CNqWr8BMt979o9fjPIhq8qAMhkDJd1JSlllNf59DrbcRpuphBrnRGj5wRy8GfKr3ZI0iJ6ztvPsUSGtZcxnLmvw7HP8Svo4ZiCfCTclrVXx5xZ1Ui/U5A/ZdqLGlKK5j3EKg/i77/pnLI4smjD+oyv+KH0ml5P6x1npfsjjuaot82K6i7cr6rcO/eFs0/jpY7U7Wr/qq0qbMMuyWsAtoUcBR6/0BHoLTten8B9bJuwGX/f1C71tWp0/JuWedA2w3+jTBbzg/yslyAipSDm3RG09fKflVsWn9dWvutC9qC5AGtLK0Bh/knJtGBp7A1DXrzfEFvm1w65WgWcjQswGG76n+NEn8ueGvC6y+vyEVYGQkZHfPHs+n8jtPVR2d5sV3AqoIKb1JMNalj/hRsWr8v0stfkV1PLrOpaBkypa4Apqx6/w5tq6yxnfUqAWDufJItAIr0qjY0gv9Fm6H/LnV0C0yhxBX/S/B5/lMy4kODV/o7VqjHG+OwF78nmnY3NcoUACWazSoa5t+sxeBHmd6oFaT7hMPOlvDOZun9rivTVLca/F+jBHOWqf2XiZD/cdlgnhaAPdUz7do1/6qMgUMexyTl1SVvYYHp1qn6hWVVmZ6za/61Qf2JFPUCoeFT4UJkD/UoeqdUdXrebukTzacB7BtFIIUKxbGItDVKSmRVbbqMVfM3RzkmDsv5GRFPu8zAfiEBSCtQ9dqPss1m9yb1/y6rHI2vABeRQ4AUPnyRcv/rhE3vl/72BpKRGD51OkZZPFNBjJYm8x/o9ahv97D0xzgrbvXECl9VqT9kzfwHescou62AeQTD8ynuqDBk5gFKsF5Rjv4etBj8naRY/SD6Gxb+OnRLI3aZtyi/uqdo1C9ZdX+WKHrbjLfsESZuQqs/CohihQ+GVurcnyrFpXXMpW6dsPEbf/dgaI8RVyujlValf9Yi/d8Ru2l5wsU8RyOAZC2hkyZHz2rbdzv8XTmGm54lalhhGACNsKQtKLu/6zbpF5tyU0QNLzIMgGZ4GSeU6Nd3/9yf1I52Oh8/8neRzP+K2ErdIgrAws2hDJ69ilatvvubO1r///7URgT6xS+5QdRQED96n6IDpNv37PwvGkagGf1cFTNpnagAr1vAOFoK9Gi6/28GeB6FpvvXFAoph6hCQbQo7Ige/U+xNqIbmf5zWEnliSp8rFpfpJ6j8EboWbK+Qwyvq0V/Q2ikZIgqVgWmBSy1Kv1SAqA5Oc4CAFMK6d9HVFGxTf8P+LLIj05/Edtx+vTDs7Tpz6vTPyKQzIVGJPrXsOuRJaq4InCtgH6D4T9XqJhPRaK/iul/yBD9jjL9iobC30q4MS30A3ToL6u8uhgTjT9r+iEqMf/xkdbFoROtC+huslN/xvRDifq/7X5g7o8hW7DkDzT98o5FDzk77q3dK3BmcOVfWWH7/5m1v843iAEGUf+Vpdvv/Z43ozFADJC0/WOe/uwreG/xsLaSnw771zz9NZFyc3dqtOfS5P+Ylf9K83jKafZ/zdOPh3ZVUhT/sEm/ewimxyYY/7JOPx7a5zXSFf+0Rj84x5X48e9lg/Fva/RDXvZguvIf1uiH2WXegOW/QN0au8ak28/8JzGe/4RKU9N9zebz3wDD+e+cKfqh5tJw/QOGTv2DPfqhD80zXP+CYbb+BfIfxubadA3XP2Fo1D9ZLP+FKMms4fo3DLP1b6bohzBJ0XT9I4bR+kfwJU0xQMF0/SuG0fpXs+X/C8QzXf+Mwat/LkWpfw6AflMqwDdc/46hXv9uv/5phlRM9z9gmOx/2DBb/zZCZg30v0hMQMX+l/GhBOoftw6Y7n/CkPQ/wbYWk2j/Gx433v+G0TXX/7ZkePSre9J0/yOGRv+j/fr3J/T6Xzek/a8YGv2v9vsfcob7nzFGFfufLbS/2+p/R4lmY/3v0P+UtvkH05JSG/n8g1GN2cfeUErnX2AUjMy/wAHAtM0/ybONIK9pdv7JCPgTaZx/g1E6bHj+jQMOcLLzj1TLTW8qzT9aBCaz4ADbmH8FKN00P/8qAAcovfPPAN4f+jD/rAfZpFTPv4NOA/Pz72D8XUrnHz4N8w+vftGf+YdLFoa/p3n+5bl+GsDOpdovOndxtXa7YX3+adLzv5xboSsbr9/p3/zbkmz+rf35b+7PA0Kh/HAK5x/v788AmJEN9uXFFudfJzn/MR9wL27F88+dPsw/1/HIzXeA5wJBpwyef78Vff59ANZD5Pn3GyYjgPIm3lNpu/9gy7wBkCGi8E3K7r+YMn/7zxoRYDZl95/sMWoAyEt4Cubuv3FN3H+zz3gEJCNJXvX1/qNFXWmehwHbxpAlQmwavv/Kj3f/lWP2/gt5BdM66/6zZUP3n+X06zkD0x7wkiR5bej+u/1G7r+DCMCkRfqTv/8Qs6tnj/+N3n+5Gvf+SxBXvi351xXef9q1fv9pxrQCyEv0n+X7b+0rgIAIMN7H+4/3wwInqwAWhOzPvf+6Hfv+66lIrkzVoAcAu8PFsybuP39fdP/5ur68BrYxBYjbY1wzcf/9v5u5/x6QhcU0BEjdYPzNeyFpT7spDtxE/09Kuz9GU9qLdo739+MGOOcj5AV6R2h7z+dd+vECfxOdQ4SwrwrPIz2mpQCKfQ6BnvTRUT3DzfmO8VyY14FHyKeobDBqKcuGQQGI20LZPD3DPqsfAHWlXzEf+RElSFHZ6Fz0eI3fzwV4h1l4MSdQHRN45sAF2HyWmTATOY+SNR0Dx1U8r2Kty2YAp0d28NKx3dQ4N9po4hLa/vEYARscNDXVF4sjGzh2B8i1QzNPa7dbd9exdan2NpVHoDET3Yp3SN+SoNNc58INONo61yMsSMh3ghgyrGfUBcZe+jjfSp5jjtQQ42SDFwxajxWx6A6Zxz5uMYZT55lr7vtEhGuSh+ljr1ELCMuWK4L43ZzQfMTwfi9/lr7H3rcx8DnQLLw9K/lyD0JaBTQC2x8RAXQVGocrkMozMNqdhWf+i2A8/57oFqu56L3LJiwAFLwVD+L6i20GEIidZz4hYVwF6mkMa2/fRWQBxbYAcqVNHfqfKAMDFAQlNEfbYAtdPeJzeawt335kSM0fQwIgngXgEM9Xpz9DCiAByE+BEM36L0BWa/tfD8DAXkUhOz9eaWdBWf45wTazzUDaIxb26Wz/+TpjcC0IgCsxw35vsfXfOqvqYBOMwHh8B/ZrWW3799eZ1fRZEr8RyoGYBMrHFtHhB0d9AdIesdBTtl6dNntwbZ4YMIGXwdFBFRpYXQO79iCWo4mINR+f87pp2jE1IKihlyXZddgEMHv2IwdRHfo1P3luN9WSiSBYm2Zlt8cK1B+CL4LBurBuUeGoCpEer5cWykDK8RMfh3eRvxPOem4XAZ+FjB4nMCACqmoB/P38djqHxE4DQi364d2hWsALfmiKfAE3+sDHomBReHZxY7XXqdNTG6vAD3Ews6tNxfljKALuHfN3+bYrWCaVNmN6mWeVtgdcyAtB+GguGDgAME/m5M9aN/4Ts9rVI60LEGtm6CSvG6/krKDo5peboRrd1fDYjc2YKlAJc8zEn7carwvAl71cWNdmwlGPtokDkCdyYG03TSJwwJsVWgCsKHn5p6iZ7qM7Z9dEEGCGyIFf9FtYgA+VyT9fL9IsVFTZG69BB80o5VCJOwcvBO+RVusxaQ+vswEyQvVCnR8TUqajyWMqx38OxT274QMwbmISJOAVP+Ryct29XCCIbvIipE36bPtyK7nkI8GzDqwrn+Osa2KfbjCSGp8yNVg9tGRijFDXtoEDt/K9Vksi/gpYIhygDsBc7KwfDtTnNqhMIMJ59Uulfl0Hb5UleOePcRawRxkJqAyhTYwkgiF87/0KXZwFxpHkcqVXvhBQ/yQERlHPv2QB21j07gl5pzPEUCncDx/rdN6ltyH3u06nc9xXu13qJG8FnobAOCUA8oE0Sg7WDu04lsI5aZCA9vF4fXeo+w6Dsy6HrcpZRD5grMmh32dk4anLZUEC2sf5EBXe1Tuh/PflowEeBQPkK9zJxGp0DPP7ApquaRkjbZqMTu0+OgHB8JhRLaiOUqG/HWIjpx7NBrRQOYdQB9MFzEcar6nQvxXWI2towJxlgHKT4yPYOTC5EN5SoH8qvN0ZAiowOYz8K1HAGPSRgsmNgIKqrAxHljL528hDsQ0ITUgwC0FvgctVYLh/1JpkqMT3QuIMAM3jYngNCHrzxiXixFqb4d05lMJz6skyAMC99Y9EhDMQ9OZuP24PqLJqPKpU0GOJUq3J4QS6Y2z++OUd9oeg9+7tLx/x700M4U2KXGPFCBYphZcn8cIA5udn3FuF+XsjNPxdjdXFnaD3AgFce0DE6xvsYXHnWH1eI3QpeRVJgPRgeJdog6D3BvYrnUNMBsgyM3xVaqGGSfISQJ6+8UB2n2bVA7tVFgNkmKO+snT+aSO1DDAcdv3cOjZ3kUE8R8v6K5ykwKeoe+er9FCOZwKuU1MyuyjDjE35gJnin6GC726APpo4cFtVcUd2s4vIphnHeJmZ4MnTHuMCSo4nChxZhtOZwXIey4pJWtc1eTmbMR8YAD01cWAztwkvCkzNy/X6lPyY5eZsyl2KAUZTRH6ekUJbxqcfb+scJQAn+Xf7ln7ZAAZIgRGE9TR9ALLwb9GCTVBnotQQnCzv4xZ4xVBUlQ58HyfRZBF7YIBVqtNxXeHhaRKBHB+/3HRAxjWFJ+YsZQEdFDIXIHYs3MJEJYmlhoqPXF6ZuBOIUtXJ4w2Ny5DwZbJN+ZyZ/fU0nwAniHT5ulun0wRZrlo7L3h64qhKJipI+npGcbgH4ykeB5QTt4KeULsNBiODqlqrfH3xJo/JXrNKrM7ZlNZsBjQLLwgEpvMJ4QfS7QP7shiyprcpWkDmhGf6cXbQsZSoEvxW+SZojAzygapiw/7pRzt1URzVPqaJBCX5KDpPc9gDa2xlQjgvzwQp2E1dOtxT1KIfwmP2kRfKPnm1QhZ1dq4puPZSGZi87Cv8GtTVAeH6IRWRUdhQwsDNJMjvicYInVAZXRugM9KTS4A2++oJ23APiQ+9in26jEzEBaQTENrp0ILfim/Ay6mI8j3ojyC6s6Jrb3tdu+S/L7kEKa/Ss5jBNtKiNLxdJaIFSJ58Mq58d4+DhaRTRzFz5DclvwDvy0xe6HpWGu4zyookV7QnOHp/sCX6viFEzP4Q3igrNT1MMPtgfK7Q4KH0cFKSH3u8e+HfKgIQ2dQis3Yv4eOmdb2PMQuUKdA/HHKSqAzPX0WY4Hyt/0avzONt7rq7b1Lthq8K+3Ktd0Sf0RjBYXh2nhBw5B9Sa9lmznapCtnZJRzgwQHm8R9EhiKiX/WCA5wfJ//Nt5otS0GoXZFiRYv+LeafTePzLDeAUDurcTwTEDl8Kf1YmRf4JJ7GtKwRGcof9kPt/QtRwNgQol+uACdwx5VgpNI5IsdvzLIAFK7JUdSjfy/HTDwvaDfJEjFg2UzC+YaoYUWdfqGb8CPCazfJAR9KcHLVZtEzwNejf4SbI/4gvJ3Xj7da/onWZRg1qILfxj8EMO1KFWOadxc7KAKArOwY8H5pYAWe/ISooxg+pAXlKz7NLwCsgA3qcbpnryL9AT/c83/Mne1rHGUQwFd6epe7a0nQ3ebOph/8C+6I2lqJbBCPfBBJSECqNqQ0UG1BVkQRo3BHwJxY5BY1uCiyxZoWROiBGPCDXOiX+kEwXxT8IBVR/DO8u9zN9WZnd2bzZF/mU8jb7e95mWdmnp0ZxQGAwgZbhz/yNuUrH21k5P8y0bxWQK6mulw4ax2G/p25pdDLDSl2XXh73vJNJD8a0T+5odAgUS5lfLAJ+dcYq0NNIGFRPPN/h4cHDtS7WuQATPpvQShVriRQsNdi2e+gTE6ZYD2eE/aubgC/n+SeOhp4qFU426Q1Yra5OeuojbZJH2w8P1MTcXtMod+YVx6FktPPXW32ZLP7xZzjTKlLSd67GvMzkutOTU+6kwfGRfqk7IlsrCny05JPKf+avHc15n+MEVxRKZVy2wN2OhJ+rZ1O/o4nSjETDX8jlfiGN0phRMCfWgX4KBHZ6ETAnxoFWAp42acoS1SshuD/5ayZLgX4Ym2Mf5K4plgT8S+K+O2u7XOrPwQLS2nA162sjZ1/bACcEmWNtiT8mamUyTqqWHwPeTaSRFVbzn8sbereRCeRSXWatCQdzisS/rfTZu3itF90RvE5OqAl7kn4r6eM30WauESeUYuSmqR1CX+AztOTmH6c/PQwObVlyf2HyfIHqr+rZjUBYx+bYqdJ1V4SVMc3NAF/wf+yz9IKiRl7o2mZphN86vz9Z4nnP/hVfc4eRLLOAcDLN2GwE/H1qogfK8CW6P6b5987+MVss9ncGgEvDwK7hQSmH22Ak2Eb98DgnZLwt8fDCfNoGtqxTz+uSjTpk9/BX/+clPAjC7OALtwKibl6e9j9QTujwl5/tgT8RXRPmsMP0k4q0nOMrsgABts6e/xVBPwFbEzayOgsJDP98CQAiulK7PufpoD/QRxNauCZqMY9/bj2ieFiBcCZwNdBQ7D881iVTuBTJx+36Yc1ILaA+LYF0GGH5/8LnzA5tLpidBBcv1fSd8miODqfAMXz73t8CRuvrmJMUaErBAeZi1kktgttIfH8Fz0nScNTYKAWn9+P9zEMDTVFZS4BkufPUPWRcYg9E0tYbIVq3oHqcqEJ6QQlwBqagD/vjaVkvP/8rViifkH1j4wOOgEDNOBx8Jt5/t5/0nn12o777IOkBboig422DLVrLkv4J7DVQeeKnYgQPDA1cYNOx66hBUBtmoqE/yH46GD1+kF05MHtAHfIkhR59GfE9BmWhP8NKpvAhg0UmwpcEZSBeYnYkGVqy8BPeP4GlUxdI+yRjWgNfyvAlwFZtbzRgV2/ioEtEf8e9ZbECTS4kVuBhssVg8BZCxAf1k2f9WKK+KswUpTn5ca0A1akKdEzLl6jODy8A99W4K9R/uhGEqsfZwYa33vio6+QRbMWZfw2GUgpkhOzEwE648gSnXSWO3g/fkk0ejVMFX6tSuX/Z+xo8HUGH7W6MP40kVu+anqaiUxrSvzHRwX3UIZQ5G4/PwBT+k/muELW+29i557ArjTP3xvYeqDdWdeijgQtauIBAPniP2u8Br7jbKNkaRE/ukkhPB79ZtSBoLoWagCAeJ9xJlT47x/cr+rQry0CgUgTrwR5gelX48cxjwuzd689Hc35L2+/m/lBzO+q82eWYg768pKVHsCvagr88cU8wE+TyoRwQ5nq/NDGOW7HX53fqGhy/ovAz5chS+T0w3FdnaGHqmVy+8eVVeFL8vQbJX9Ov8eowc8BQG7/LfRyNZp1wvGKVKQdzBc+7j7era0DfqZWxhUtNP/54UJ/7ZwZuwq4zPdVHOLq+wPDPnvHdwRWrXD8iND4wwquSTP4YEPZFhqu4k7I3nCTgwzSbUyOm2BK/X8kM25QSabXh47RrloSrfF4dfBxYcvCQLDq+bklLilZzn/ecZzh1J7xf4JL1jDuVEYjE070M3lm+UPbfHg825sLtNDvkAh5mGjpi+N/+t1hbuo2MQCZUV+y3uZoQHjt58Nb/C6Y17d5/OUBWGaTbGXT7AuaeTF/Y/wW5QWbikZe6yfJPVO/P/C6DtGG0HLVHIUvO/8Td74vbhRhHF/J1o2718NwJtqk9YV/QYI/rlaFhNLQGBGXFk8qiEsP6umbyJHDHz1pELVaChe0Vq1KglYtUmig1QoiLbUqiOBRxTciFrUI4v/gJZPka56dnZ0lO7PMy9zt7ueZZ2aeeZ5n5hHg10hR2BvAL2hR+RkLBnxIBYgUwnW4sypS29eAcZ0LuQI7d576/M/Ey++MWKB0wlsC4XdciFK5k07Rbni9KWudDMUU/Hrx8RttxkKuSOmE3xO6RXhvl/geMUe498X+a54EIPAPsfE3/avQXUKX3EXsW7FAS3c+CSevCcsfvOH3SXfi5jc9sODVgvdsQrIa5kyZBj+tI2H8N6lpXMVmMUZ+9lzyqlXRDTt2huZkWN9LDYJHv8VEFu76cklsF/0UKz9fr3oir0QbGRvERhDSf+irvCOScorG9puQV7z8Rtf/JZtFkm7xwnbWiz+Lxv2VV4hvPayKQYXN9OSfFhTw89YVyxV2DT9p4Zl/AiopnNje4HpWgchTsjynaH1DAT8bjkTbKoKNieUG+q7Sl+6elEHubd/VILMyrq800Q18owL+TWwwE3GXZW5KPh7iNMqWeWZN+OrnkL62sVrEz2+5Pj+cKQrKpgSJCzNeSE7nN1Ke36fJitRFnDB+fqPqN0XXRRuNNvE1c3uXX1C0Jhf4uIgfYXQXFfDTtRUCv1GuKGehTFIEhHVk6qAX2nIlqCPpIAX8PPWqiHrH9AIEcDLk/vS6bNJPG52NAaqO3/b1x3VBCyD6AwFi+OqETjnrFJWMJH8TE7QCfiwv0vw1sqn7uk9PnLISv+fm5fjb+DpF/A7MEQl+qDHWeWL7iH+HAEL58XEq+WFegl+EP30rLHsQgJi/hFNwCvj5Q6wVXGLnaBz4G3zLXnCJnR7MP0xOqvgxpeOlVzOPi5yyW751p895WnYDBVDC642L2KCr4zcqk0usC1nw8A9NkQ2J0WwHCADLL4wTlfzQsiIMro4If9psyONIauLWI7geXVHFyFTFj0NDebL/oO0kw58yQQbabLchALLFKJOZWTW/8/8tVgvyJ/gw+FLRmPm7wjRfAOZ4LmpiuCjix5YHVoaL8efHh6N8yus8IYB9/gVgK7HMFPND0qxriyJ8OMqjN1pWL92DACb8Xw1oZUcHv+WNR1qXM+FYd7LYHUkPiN4oqskTQIp9CWYl9fyYaW34Q0l1ov2NyDmZtOEREADn0W4mO16VzujhT49e1oX6+/GnFAAw0UzOw6sDBaggOqWWH26AQt9DWZDAhwCi44c/3uyrookhqZofK9rHPfgaJjR0D/DJ9CXdkJ5EBYC5FZ3xxApsH9X8WGyyeKVghiLKK9d+FdR+gwBgkLpY/HTwW1cR2hXhyxdvEmdniVfXl7FcauFHKZo5aXxUURc3unQKbWuagb6nrIX/ND+slW6HF4Az/w3v/O2hAKeIAFZRdEc9/8xnxGVPDXRxO3guhpox2FzSWMljZcX8dbi0H5HEl69okrsCpnABwC1s9UjpLXX8XazQE+EsCXzIin9EZule+c47AgGQE4drKvmR1YFFHv6J8xLsyMicHPXv7YhWJqYOAUD9YASoG/8lWhiP+qfkZfDaRrb6F68joz66AHLz9NDTgur5z0FGhw9fa9s56Re3StiWq+Q3enSn+RzwtbbJwIAFG1AdP4K6HfIZMNm0NQQG8FmH1PJD0Hl/L+hvL0Dz8FVK+VEivZM4PmYeaKUOftODqHcmio/AAOv+gj7/F5N1HXH9JBoCA01d/i9kGOepEaK/wfLx0P26/F+ZIvCTF4A2/xeM4Gzi+PCsafZ/dcmtF8k200X36+F3ksbnuGNzDU38yMzPJo+P3f+ioZF/MzITE2+7kCmhjd9yxRdSmYdvZ0exY+DbfWnjUTsOB70q7aHQjSZ+pLbu5ddLPDaeH7+acog8gGqYJ/ie0RJUURc/FCB3wU9PKoa+P4ViHjwX6ht+FnlSWvhhBPNHwIOuIJwRsZ32xwYu8LU/U9TNb3rcEfDDOJETJ8Vx8VqUhoDZ0sajjvGFaZVwxk4rPy7dLvorRi+NnJnmZaQyRGpImhgfV989PMd/lneK5Ix+fhtJSpNp/dv+nEgVeBixgijNIuVrcJ3FWc4ha0MnP4xgRAGR6PQlMZTWBuGqn6LyX+tjrZP0KnMQ/Z33Rf4WkuBP0UDQKscZUMnkjToOMUi32sC6dn2KfYQtOhj82Pno5IcRjA6Z8TgbglRfN+tYKCQanmVzTpft9MbPuoxCeInwO5MnVEq8DYHl9S2TWlQd7Q6etYk3rz/PFh32UA+mr15+nLfY5rJuX2VnmGgrDcCvYZ6UaQ5Tqi43u7LGIu/LfaWC0183P4zgPwb5GBbO4ZO/mRvOVAfk+XvsagmXmDXIQM4Pbh3LHoXpq5sfRvAtfUXcvysg995mG3MnyixlM22Z5e7pmTA/cfvqhliUdn6EAnLljwK3IOjEboTQdIvNFiuQKHfz9fksXqufH0bwolUSDMMWG8S2/NkMy2O6UsocENlGb43yEJPjN6pMAQa2ajnoMsICG7XkL4RFCReYGIqCsoX7kIeaHP/M0PxKtwP1MD3kdqQHQIutaKngGWNlkARaRdJrUvxGd2h/zXBOAsAEDrsrgc4YWxlkPvgv5hoGkl4T5LeZAuAkjL9VhtwVQSUyolM/Mrk9FGgeZMtIQ0+U3yiNvqId9Lkpxo27EsKHfxlHq/hKt2ig+5Pld0YK0AyaiS2PlQgyJb00FfYgJ2BXyyQznnoT5Ucu9GA4dsSH9NdljqaPrd4K36XL7ILx0vtfd+fz2lQQxPGFvJg0WvFRozYaKf4FlvUHtVjiwaCe8lDwFwiBgooeIiVSpUqKFZ4SiqGgBilE/HFOUPHioQURxUtLRaknBRX/DE2z3xi7b8wEha47pxySw+flzXd3Z2Zntv0T6/sL/jAUYJZSwLybUGAbeZvfDGSTUr9biD+mVp4/4ikFCFEKGFNv8gXOAoANY9R1C6T6QfwTYuX5RR5x0HmlRgSRCPN2gA3d61KqSagfajAM4HdwCCcVcLyxke3i8heWfrOJVL8Z1T6mRxjAD1ccrkuSHgAAeKf8Jcr9024PYo9VI/jxAlTELOHg0cY6xedXu2ZCbuZECEF/E/jhjFvrCpgiJL3aGb8KfRHqp2LjVUP4kQuqQgGJa/qreKGKrFvBJiAw+DMs9uPvN4MfChDPaQroFKWclvKGm1QHAYaV6n7tuU9vysHyE/laO03OqJzfdmP4kQ0eXqaAYwOt7ev1XlH0djHW2hOwsEz9+pHxNYYfEalPWLWQrGnNAmuSTvf0ijwKaLYO9VMZ74pJ/EqRklehgAGDeE5pveKoodzJWsCVOKjfWBY5D4P4kQw7X4MCjmRd3XK84L9uvQWo35l+ZF2N4kebk2dKAUPZYAqGHaJntURddyfu3pnFj1zshoYuRz2io/vUkJ+i0aNFuZglWqHktGGGRvDrtzC3tJuAFi9PySH/p02IqO+nIvWPRSkXy+1mP0Y8KGLBNH60oMBJCHZ2QUqJGq7OrHfZTyuiW2snagK/Xo3gZFsb2tXtWqljevRBnnzf7KPdD18QJvKLEQWQTOvXkWNLBM7k4J9f8vi09EfxhsPeKkl4gS8VzONH/QvZ8dNrzpodLcq9epu/clkqaezWkpqX4QQotzCRHwUpsGRKT5RUfxN7v2kprbAsQ4/YOiYM5ceyF1gbHmZPJagFJHVHWhdCc/lFyKXmTce43fmcwIK2Vy0bIVP5UZQTTOox7yiE4P7a4oJSI5P5oYEVPWzLLNO9GNzDNw/tM5xffCNqUsKcKWbYOlaIGNM7YTY/WhRViUxxglH8QdSzptFgwnB+4dSCY5ceq1B3LfWYnCxWPsP5hTNfJUolGMVKYbKFd/qEMJwf5jDJOntKTs5Efr7FiEkufC/5v/mFx5hMswbubxs/BKDAGN2bsZM/zOhPNA73t5A/xjgCleD+tvFDADa3P/wkrOSHAKTaxv4zVvJDAE7umaAvDZfg/lbyN7Oax6fkd7/lMfj+A4nBtXB/u/ghAAxL2Mt/n8OfsZc/zOGv2MsfY+DHhY38fAFIWMzPmAUen7OTH+bLMs1+D3sDO/lhByblAJZ7DK5fkMgCGcdvv/X9AMxFumDADjNpAAAAAElFTkSuQmCC",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 12406
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 2.52799998270348,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.47699999413453,
+          "wait": 113.96099999546999,
+          "receive": 1.2980000174139263,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.321Z",
+        "time": 235.42299997643568,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/logos/logoBig2.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/logos/logoBig2.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "2.576ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"61c7-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/svg+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 25031,
+            "mimeType": "image/svg+xml",
+            "text": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI5MC40ODgiIGhlaWdodD0iMTkuNTQzIiB2aWV3Qm94PSIwIDAgOTAuNDg4IDE5LjU0MyI+PGcgZmlsbD0iI0ZGRiI+PHBhdGggZD0iTTgzLjgyOCAxOC40MTdjMCAuMzI3LS4wOS41OTUtLjI3LjgtLjE4My4yMDgtLjQwOC4zMTItLjY4LjMxMi0uMTE1IDAtLjIxNy0uMDItLjMwNS0uMDQtLjA4OC0uMDMtLjE3LS4wNi0uMjUtLjExbC0uMDI4LjFoLS42NDJWMTYuNmguNjd2MS4wMmMuMTAzLS4wOC4yMDctLjE0Ny4zMTQtLjE5OC4xMDYtLjA1LjIzLS4wNzYuMzctLjA3Ni4yNjMgMCAuNDY1LjA5Ni42MDcuMjg1LjE0Mi4xOS4yMTQuNDUuMjE0Ljc5em0tLjY5LjAxM2MwLS4xODYtLjAzLS4zMjgtLjA5NC0uNDI4LS4wNjItLjEtLjE3NS0uMTUtLjMzNy0uMTUtLjA2MiAwLS4xMjguMDEtLjE5NC4wM3MtLjEzLjA0NS0uMTkuMDh2MS4wNDZjLjA0OC4wMTguMDk0LjAzLjEzNy4wMzVzLjA5NS4wMS4xNTUuMDFjLjE3NyAwIC4zMS0uMDUzLjM5NS0uMTU2LjA4Ni0uMTAzLjEzLS4yNi4xMy0uNDY3em0zLjIyNC4xNGgtMS41MjhjLjAxLjE2Mi4wNzIuMjg3LjE4Ny4zNzMuMTIuMDg3LjI5LjEzLjUxLjEzLjE0IDAgLjI4LS4wMjUuNDEtLjA3Ni4xMy0uMDUuMjQtLjEwNC4zMS0uMTYzaC4wOHYuNTM2Yy0uMTUuMDYtLjI5LjEwNC0uNDIuMTMyLS4xMy4wMjctLjI4LjA0LS40NC4wNC0uNDIgMC0uNzQtLjA5My0uOTYtLjI4cy0uMzMtLjQ1Ny0uMzMtLjgwNGMwLS4zNDUuMTEtLjYxNy4zMi0uODE3LjIxLS4yLjUtLjMuODctLjMuMzQgMCAuNi4wOS43Ny4yNnMuMjYuNDIuMjYuNzR2LjI0em0tLjY2NC0uMzkzYy0uMDA0LS4xNC0uMDM4LS4yNDUtLjEwNC0uMzE1LS4wNjUtLjA3LS4xNjgtLjEwNi0uMzA3LS4xMDYtLjEyOCAwLS4yMzQuMDM0LS4zMTcuMS0uMDgyLjA2Ny0uMTMuMTc1LS4xNC4zMjJoLjg2OHptMi40NjggMS4yOWMtLjA3LjAyLS4xNDcuMDM0LS4yMjguMDQ1LS4wOC4wMS0uMTguMDE2LS4yOTYuMDE2LS4yNiAwLS40NTMtLjA1My0uNTgtLjE1OC0uMTI2LS4xMDQtLjE5LS4yODUtLjE5LS41NHYtLjk3NEg4Ni42di0uNDUzaC4yNzN2LS41OTZoLjY3di41OTZoLjYyM3YuNDUzaC0uNjIzdi43NGMwIC4wNzIgMCAuMTM2LjAwMi4xOSAwIC4wNTUuMDEuMTA0LjAzLjE0N3MuMDQ3LjA3Ny4wOS4xMDMuMTA4LjAzOC4xOTIuMDM4Yy4wMzQgMCAuMDgtLjAwNy4xMzYtLjAyMi4wNTctLjAxNS4wOTYtLjAyOC4xMTctLjA0aC4wNTZ2LjQ1NnptMS42Ni0uMmwtLjEzNC4xYy0uMDUzLjAzNi0uMTA0LjA2Ni0uMTUuMDktLjA2NS4wMy0uMTMzLjA1LS4yMDQuMDY0LS4wNy4wMi0uMTQ3LjAzLS4yMy4wMy0uMiAwLS4zNjUtLjA2LS40OTgtLjE4LS4xMzQtLjEyLS4yLS4yOC0uMi0uNDcgMC0uMTUuMDMzLS4yNy4xMDItLjM3LjA2OC0uMDkuMTY0LS4xNy4yOS0uMjMuMTIzLS4wNS4yNzYtLjA5LjQ2LS4xMi4xODMtLjAyLjM3Mi0uMDQuNTctLjA1di0uMDFjMC0uMTEtLjA0OC0uMTktLjE0My0uMjMtLjEtLjA0LS4yNC0uMDYtLjQyLS4wNi0uMTEgMC0uMjMuMDItLjM2LjA2cy0uMjIuMDctLjI3LjA5aC0uMDZ2LS41Yy4wNy0uMDIuMTgtLjA0LjM0LS4wNy4xNi0uMDIuMzItLjAzLjQ4LS4wMy4zOCAwIC42NS4wNi44Mi4xN3MuMjUuMy4yNS41NXYxLjQyaC0uNjd2LS4yMnptMC0uMzI1di0uNDMzYy0uMDkgMC0uMTg4LjAxLS4yOTMuMDMtLjEwNS4wMS0uMTg2LjAyLS4yNC4wNC0uMDY2LjAyLS4xMTcuMDUtLjE1Mi4wOXMtLjA1LjA5LS4wNS4xNmMwIC4wNC4wMS4wOC4wMS4xLjAxLjAyLjAzLjA1LjA2LjA3cy4wNi4wNC4xMS4wNWMuMDQuMDEuMS4wMi4xOS4wMi4wNyAwIC4xNC0uMDIuMjEtLjA0LjA3LS4wMy4xMy0uMDcuMTgtLjExem0tNjkuNTEtNi41MjJjLjE0My4wOC4zMDMuMTYuNDguMjM1cy4zNy4xNC41NzMuMTljLjIuMDUuNDEuMDc2LjYyLjA3Ni4xMyAwIC4yNy0uMDEuNDEtLjAzLjE0LS4wMi4yNi0uMDYuMzctLjEycy4xOS0uMTQuMjYtLjI0Yy4wNy0uMS4xLS4yMy4xLS4zOSAwLS4yOS0uMTItLjUtLjM1LS42My0uMjMtLjEyLS41Ny0uMjMtMS4wMy0uMzMtLjMtLjA2LS41OC0uMTQtLjg2LS4yNC0uMjgtLjEtLjUyLS4yMy0uNzMtLjQtLjIyLS4xNy0uMzktLjM4LS41MS0uNjMtLjEzLS4yNS0uMi0uNTYtLjItLjkzcy4wOC0uNjkuMjQtLjk2LjM4LS41MS42NS0uN2MuMjctLjE5LjU4LS4zNC45NC0uNDMuMzUtLjEuNzItLjE0IDEuMTEtLjE0LjQxIDAgLjc3LjAzIDEuMDkuMDkuMzIuMDYuNi4xNC44My4yNS40NS4xOC42OC40Mi43LjcyIDAgLjE1LS4wNS4zMy0uMTQuNTRzLS4yLjQtLjMxLjU5Yy0uMTEtLjA4LS4yMy0uMTYtLjM4LS4yNS0uMTUtLjA4LS4zMi0uMTctLjUtLjI0LS4xOC0uMDgtLjM4LS4xNC0uNTctLjE5cy0uNC0uMDctLjYtLjA3Yy0uMTIgMC0uMjMuMDEtLjM1LjAycy0uMjQuMDUtLjMzLjA5Yy0uMS4wNS0uMTguMTItLjI1LjItLjA3LjA5LS4xLjItLjEuMzUgMCAuMzUuMzcuNiAxLjExLjc3LjMuMDYuNi4xNC45LjI0LjMuMS41Ny4yMy44MS40MXMuNDMuMzkuNTguNjVjLjE0LjI2LjIyLjU5LjIyLjk5IDAgLjQxLS4wOC43Ny0uMjQgMS4wOC0uMTYuMzItLjM4LjU4LS42NS44cy0uNi4zOC0uOTcuNDljLS4zNy4xMS0uNzguMTctMS4yMS4xNy0uNDUgMC0uODMtLjAzLTEuMTQtLjFzLS41Ny0uMTQtLjc3LS4yNGMtLjE0LS4wNi0uMy0uMTUtLjQ2LS4yNy0uMTctLjEyLS4yNi0uMjgtLjI2LS40OCAwLS4xNy4wNS0uMzUuMTUtLjU0LjEtLjE4LjIyLS4zOC4zNS0uNTguMDkuMDguMi4xNy4zNC4yNnptNi40OTctOC4xNDVjLjU5NSAwIDEuMDc4LjQ4MyAxLjA3OCAxLjA3OHMtLjQ4IDEuMDc3LTEuMDcgMS4wNzctMS4wNy0uNDgyLTEuMDctMS4wNzdjMC0uNTk2LjQ4LTEuMDc4IDEuMDgtMS4wNzh6bS0uOTc2IDIuNjU0Yy4wMy0uMDEuMTE0LS4wMy4yNTItLjA0LjEzLS4wMi4yOC0uMDMuNDUtLjAzcy4zMi4wMS40OC4wNGMuMTYuMDMuMzEuMDkuNDQuMTdzLjI0LjIxLjMyLjM2LjEyLjM2LjEyLjYydjYuMTZjLS4wNC4wMi0uMTMuMDQtLjI4LjA1LS4xNC4wMS0uMy4wMS0uNDYuMDEtLjIxIDAtLjM5LS4wMi0uNTUtLjA2LS4xNy0uMDQtLjMtLjEtLjQyLS4ycy0uMjEtLjIzLS4yOC0uMzljLS4wNy0uMTYtLjEtLjM3LS4xLS42MlY2Ljl6bTMuMDUtMi4yOGwuMjMtLjAzLjIzLS4wM2MuMDgtLjAxLjE2Mi0uMDEuMjQzLS4wMS4xNjMgMCAuMzI1LjAxLjQ4OC4wNHMuMzEuMDkuNDQyLjE4LjI0LjIxLjMyLjM3LjEyMi4zNi4xMjIuNjF2MS4wN2gyLjEzNXYxLjU2aC0yLjEzNXYzLjI3YzAgLjcxLjI5IDEuMDYuODcgMS4wNi4xNCAwIC4yNzYtLjAyLjQwMy0uMDdzLjI0Mi0uMS4zNDMtLjE1Yy4xMDItLjA2LjE5LS4xMi4yNjctLjE4LjA3Ni0uMDYuMTMtLjExLjE2LS4xNC4xNTIuMjIuMjcuNDIuMzUuNTguMDgyLjE2LjEyMy4zMS4xMjMuNDYgMCAuMTMtLjA1My4yNi0uMTYuMzlzLS4yNTcuMjQtLjQ1LjM1Yy0uMTkzLjEtLjQyNy4xOS0uNy4yNi0uMjc1LjA2LS41NzUuMDktLjkuMDktLjYzMiAwLTEuMTIyLS4xMi0xLjQ3My0uMzdzLS41OTctLjU2LS43NC0uOTZjLS4wNy0uMjEtLjExNy0uNDItLjEzNy0uNjQtLjAyLS4yMy0uMDMtLjQ1LS4wMy0uNjdWNC42NXptNi44OTQgNi4yNGMuMDUuNTYuMjIgMS4wMi41MiAxLjM5LjMxLjM3Ljc5LjU1IDEuNDUuNTUuMjYgMCAuNDgtLjAzLjY3LS4wOXMuMzctLjEzLjUyLS4yMWMuMTYtLjA4LjI5LS4xNy40LS4yN2wuMzEtLjI3Yy4xMy4xNS4yNS4zNC4zOC41OHMuMi40My4yLjU4YzAgLjIyLS4xMi40Mi0uMzguNjEtLjIxLjE2LS41MS4zLS45MS40Mi0uMzkuMTEtLjg1LjE3LTEuMzguMTctLjQ3IDAtLjk0LS4wNi0xLjQxLS4xOC0uNDYtLjEyLS44Ny0uMzQtMS4yMy0uNjRzLS42NS0uNzItLjg3LTEuMjNjLS4yMi0uNTItLjMzLTEuMTctLjMzLTEuOTUgMC0uNjQuMS0xLjE5LjMtMS42NXMuNDYtLjg1Ljc5LTEuMTVjLjMzLS4zMS43MS0uNTMgMS4xMi0uNjdzLjg1LS4yMiAxLjI4LS4yMmMuNTcgMCAxLjA2LjA5IDEuNDUuMjYuNC4xOC43Mi40Mi45Ny43MnMuNDMuNjQuNTQgMS4wM2MuMTIuMzguMTcuNzkuMTcgMS4yMnYuMjFzMCAuMTctLjAxLjI2bC0uMDEuMjZzLS4wMS4xNS0uMDIuMmgtNC41em0yLjY2LTEuMTVjMC0uNDktLjA5LS44OS0uMjgtMS4xOXMtLjUyLS40Ni0xLjAxLS40NmMtLjQxIDAtLjc1LjE0LTEgLjQzcy0uMzcuNjktLjM3IDEuMjFoMi42N3ptMy4zNyAyLjY3Yy4xNC4wOC4zLjE2LjQ4LjIzcy4zNy4xNC41Ny4xOWMuMjEuMDUuNDEuMDcuNjMuMDcuMTMgMCAuMjctLjAxLjQxLS4wMy4xNS0uMDIuMjctLjA2LjM4LS4xMi4xMS0uMDYuMi0uMTUuMjctLjI1cy4xMS0uMjMuMTEtLjRjMC0uMy0uMTEtLjUxLS4zNC0uNjMtLjIzLS4xMy0uNTctLjI0LTEuMDMtLjMzLS4yOS0uMDYtLjU4LS4xNC0uODUtLjI1LS4yNy0uMS0uNTItLjI0LS43My0uNDEtLjIxLS4xNy0uMzgtLjM4LS41MS0uNjMtLjEyLS4yNi0uMTktLjU3LS4xOS0uOTNzLjA4LS42OS4yNS0uOTZjLjE3LS4yOC4zOC0uNTEuNjUtLjcuMjctLjIuNTgtLjM0Ljk0LS40NHMuNzMtLjE1IDEuMTItLjE1Yy40MSAwIC43Ny4wMyAxLjA5LjA5LjMyLjA2LjYuMTQuODMuMjQuNDUuMTguNjguNDIuNy43MSAwIC4xNS0uMDUuMzMtLjE0LjU0cy0uMi40LS4zMS41OGMtLjEtLjA4LS4yMy0uMTctLjM3LS4yNS0uMTUtLjA5LS4zMS0uMTctLjQ5LS4yNS0uMTgtLjA4LS4zNy0uMTQtLjU3LS4xOS0uMi0uMDUtLjQtLjA4LS42LS4wOC0uMTEgMC0uMjMuMDEtLjM1LjAycy0uMjMuMDQtLjMzLjA5Yy0uMDkuMDQtLjE3LjExLS4yNC4yLS4wNy4wOC0uMS4yLS4xLjM0IDAgLjM1LjM3LjYgMS4xMS43Ni4zMS4wNi42MS4xNC45MS4yNC4zLjA5LjU3LjIzLjgxLjRzLjQzLjM5LjU4LjY1LjIyLjYuMjIuOTljMCAuNDEtLjA4Ljc3LS4yNCAxLjA5LS4xNS4zMi0uMzcuNTgtLjY1LjhzLS41OS4zNy0uOTYuNDljLS4zNy4xMS0uNzcuMTctMS4yMS4xNy0uNDUgMC0uODItLjA0LTEuMTMtLjFzLS41Ny0uMTUtLjc3LS4yNGMtLjE0LS4wNi0uMy0uMTUtLjQ3LS4yNy0uMTctLjEyLS4yNS0uMjgtLjI1LS40OCAwLS4xOC4wNS0uMzYuMTUtLjU0OC4xLS4xOC4yMi0uMzguMzUtLjU4LjA5LjA4LjIuMTcuMzMuMjZ6bTUuNTUtNS40OWMuMDUtLjAxLjExLS4wMi4xOC0uMDMuMDYtLjAxLjE0LS4wMi4yMi0uMDMuMDgtLjAxLjE4LS4wMS4yOS0uMDEuMzQgMCAuNjIuMDUuODYuMTZzLjM4LjMuNDQuNTZjLjE2LS4yLjQyLS4zOS43Ni0uNTlzLjc5LS4zIDEuMzEtLjNjLjM4IDAgLjc0LjA2IDEuMDguMTlzLjY1LjMzLjkxLjYyLjQ4LjY2LjYzIDEuMTJjLjE2LjQ3LjI0IDEuMDQuMjQgMS43MiAwIC43OS0uMDkgMS40NS0uMjcgMS45Ni0uMTguNTEtLjQyLjkyLS43MSAxLjIycy0uNjEuNTEtLjk3LjYzYy0uMzUuMTItLjcxLjE4LTEuMDYuMTgtLjMgMC0uNTUtLjAzLS43Ny0uMS0uMjItLjA3LS40LS4xNC0uNTYtLjIyLS4xNS0uMDgtLjI3LS4xNi0uMzUtLjI1LS4wOC0uMDgtLjEzLS4xNC0uMTUtLjE3djIuMzFoLTIuMDZ2LTl6bTIuMDggNS4zNWMuMDguMDguMjMuMTcuNDQuMjkuMjEuMTEuNDUuMTYuNzMuMTYuNTIgMCAuOS0uMjEgMS4xNS0uNjFzLjM3LS45OC4zNy0xLjcxYzAtLjMxLS4wMi0uNTktLjA3LS44NnMtLjE0LS41LS4yNS0uNjktLjI3LS4zNS0uNDctLjQ1Yy0uMi0uMTEtLjQ0LS4xNi0uNzItLjE2LS40MiAwLS43Mi4wOC0uODkuMjQtLjE3LjE2LS4yNS4zNC0uMjUuNTN2My4yM3ptNy42Ni0xLjM5Yy4wNC41Ni4yMiAxLjAyLjUyIDEuMzkuMzEuMzcuNzkuNTUgMS40NS41NS4yNiAwIC40OC0uMDMuNjctLjA5cy4zNy0uMTMuNTItLjIxYy4xNS0uMDguMjktLjE3LjQtLjI3bC4zMS0uMjdjLjEyLjE1LjI1LjM1LjM4LjU4cy4yLjQzLjIuNThjMCAuMjItLjEzLjQyLS4zOC42MS0uMjEuMTYtLjUxLjMtLjkxLjQyLS4zOS4xMS0uODUuMTctMS4zOC4xNy0uNDggMC0uOTUtLjA2LTEuNDEtLjE4LS40Ni0uMTItLjg3LS4zNC0xLjIzLS42NC0uMzYtLjMxLS42NS0uNzEtLjg3LTEuMjMtLjIyLS41MS0uMzQtMS4xNi0uMzQtMS45NCAwLS42NC4xLTEuMTkuMy0xLjY2LjItLjQ2LjQ3LS44NS44LTEuMTUuMzMtLjMuNzEtLjUzIDEuMTItLjY3cy44NS0uMjEgMS4yOC0uMjFjLjU3IDAgMS4wNi4wOSAxLjQ1LjI2cy43Mi40Mi45Ny43Mi40My42NC41NCAxLjAzYy4xMS4zOC4xNy43OS4xNyAxLjIydi4yMWwtLjAxLjI2LS4wMS4yN2MwIC4wOS0uMDEuMTYtLjAyLjIxaC00LjV6bTIuNjUtMS4xNGMwLS40OS0uMDktLjg5LS4yOC0xLjE5cy0uNTMtLjQ2LTEuMDEtLjQ2Yy0uNDIgMC0uNzUuMTQtMSAuNDNzLS4zNy42OS0uMzcgMS4yMWgyLjY3em00LjU4IDEuMTRjLjA0LjU2LjIyIDEuMDIuNTIgMS4zOS4zMS4zNy43OS41NSAxLjQ1LjU1LjI2IDAgLjQ4LS4wMy42Ny0uMDlzLjM3LS4xMy41Mi0uMjFjLjE2LS4wOC4yOS0uMTcuNC0uMjdsLjMxLS4yN2MuMTIuMTUuMjUuMzQuMzguNTguMTMuMjQuMi40My4yLjU4IDAgLjIyLS4xMy40Mi0uMzguNjEtLjIxLjE2LS41MS4zLS45MS40Mi0uMzkuMTEtLjg1LjE3LTEuMzguMTctLjQ4IDAtLjk1LS4wNi0xLjQxLS4xOC0uNDYtLjEzLS44Ny0uMzQtMS4yMy0uNjQtLjM2LS4zMS0uNjUtLjcyLS44Ny0xLjIzLS4yMi0uNTItLjMzLTEuMTctLjMzLTEuOTUgMC0uNjQuMS0xLjE5LjMtMS42Ni4yLS40Ny40Ny0uODUuOC0xLjE2LjMzLS4zMS43MS0uNTMgMS4xMi0uNjdzLjg1LS4yMiAxLjI4LS4yMmMuNTcgMCAxLjA2LjA5IDEuNDUuMjcuNC4xOC43Mi40Mi45Ny43MnMuNDMuNjQuNTUgMS4wM2MuMTIuMzkuMTcuNzkuMTcgMS4yMnYuNDdsLS4wMS4yNmMtLjAxLjA5LS4wMS4xNi0uMDIuMjFoLTQuNDl6bTIuNjUtMS4xNGMwLS40OS0uMDktLjg5LS4yOC0xLjE5LS4xOS0uMzEtLjUyLS40Ni0xLjAxLS40Ni0uNDEgMC0uNzUuMTQtMSAuNDNzLS4zNy42OS0uMzcgMS4yMWgyLjY3em03LjQ1LTEuMDFjLS4wOC0uMDgtLjIyLS4xOC0uNDItLjI5LS4yLS4xMS0uNDMtLjE3LS42OS0uMTctLjUzIDAtLjkyLjE5LTEuMTguNTgtLjI1LjM4LS4zOC45NC0uMzggMS42NiAwIC4zNS4wMy42OC4wOC45Ny4wNS4yOS4xNC41My4yNi43NC4xMi4yLjI5LjM2LjQ5LjQ3LjIxLjExLjQ3LjE2Ljc4LjE2LjMgMCAuNTUtLjA2Ljc2LS4xOXMuMzItLjMuMzItLjUydi0zLjR6bS43MiA1LjRjLS4xNyAwLS4zMS0uMDYtLjQxLS4xOC0uMTEtLjEyLS4xNi0uMjctLjE2LS40NS0uMTQuMTctLjM4LjM1LS43Mi41My0uMzQuMTktLjc3LjI4LTEuMy4yOC0uMzcgMC0uNzQtLjA2LTEuMDktLjE5LS4zNS0uMTItLjY2LS4zMy0uOTQtLjYxcy0uNDktLjY2LS42NS0xLjE0Yy0uMTYtLjQ4LS4yNC0xLjA2LS4yNC0xLjc2IDAtLjcxLjA5LTEuMy4yNS0xLjguMTctLjUuMzktLjkxLjY3LTEuMjJzLjYtLjU0Ljk2LS42OS43NC0uMjIgMS4xNC0uMjJjLjQ2IDAgLjg0LjA4IDEuMTMuMjMuMy4xNi41Mi4zMS42Ni40NlY0LjZjLjA3LS4wMi4xOC0uMDM1LjMyLS4wNDYuMTUtLjAxLjI3LS4wMTIuMzgtLjAxMi4xNyAwIC4zMy4wMS41LjA0cy4zMi4wOS40NS4xOC4yNC4yMS4zMS4zN2MuMDguMTYuMTIuMzYuMTIuNjJ2OC4zN2gtMS4zNnptMi41OS0uMDZjLS4yLS4yMi0uMy0uNDktLjMtLjgxcy4xMS0uNTkuMzItLjc5Yy4yMS0uMjEuNDctLjMxLjc5LS4zMXMuNTkuMS44LjNjLjIxLjIuMzIuNDcuMzIuNzkgMCAuMzItLjEuNTktLjMuOC0uMi4yMS0uNDcuMzItLjgxLjMyLS4zMyAwLS42LS4xLS44MS0uMzF6bTIuNzQtNy4wMmMuMDMtLjAxLjEyLS4wMy4yNS0uMDQuMTQtLjAyLjI4LS4wMi40NS0uMDJzLjMyLjAxLjQ4LjA0LjMxLjA4LjQ0LjE3LjI0LjIuMzIuMzZjLjA4LjE1LjEyLjM2LjEyLjYxdjYuMDdjLS4wNC4wMi0uMTMuMDMtLjI3LjA0LS4xNC4wMS0uMjkuMDEtLjQ1LjAxLS4yIDAtLjM4LS4wMi0uNTQtLjA1LS4xNi0uMDQtLjMtLjEtLjQxLS4yLS4xMi0uMS0uMjEtLjIyLS4yNy0uMzgtLjA3LS4xNi0uMS0uMzctLjEtLjYydi02em0wLTEuNjRjMC0uMzIuMTEtLjU5LjMyLS43OS4yMS0uMjEuNDctLjMxLjc4LS4zMS4zIDAgLjU2LjEuNzguMzEuMjIuMi4zMi40Ny4zMi43OSAwIC4zMi0uMTEuNTgtLjMyLjc4LS4yMS4yLS40Ny4zLS43Ny4zLS4zMSAwLS41Ny0uMS0uNzgtLjMtLjIxLS4yMS0uMzEtLjQ3LS4zMS0uNzl6bTMuNzMgNy44NWMtLjI4LS4zNS0uNDgtLjc2LS42MS0xLjIxcy0uMTktLjk0LS4xOS0xLjQ0YzAtLjUxLjA4LTEgLjIzLTEuNDUuMTUtLjQ2LjM3LS44Ni42Ny0xLjIxLjI5LS4zNS42Ny0uNjIgMS4xMi0uODIuNDUtLjIuOTctLjMgMS41OC0uMy42MyAwIDEuMTcuMSAxLjYxLjMuNDQuMi44MS40NyAxLjA4LjgxLjI4LjM0LjQ4LjczLjYgMS4xOC4xMy40NS4xOS45My4xOSAxLjQzcy0uMDYuOTgtLjE5IDEuNDRjLS4xMi40Ni0uMzMuODctLjYxIDEuMjJzLS42NS42My0xLjEuODRjLS40NS4yMS0xIC4zMS0xLjY0LjMxcy0xLjE5LS4xLTEuNjMtLjNjLS40NS0uMjEtLjgxLS40OC0xLjA5LS44MnptMS45OS0uNmMuMi4xMy40NS4xOS43NC4xOS4zIDAgLjU1LS4wNy43NS0uMnMuMzUtLjMuNDYtLjUyYy4xMS0uMjIuMTktLjQ2LjIzLS43M3MuMDYtLjU1LjA2LS44M2MwLS4yNy0uMDItLjU0LS4wNi0uODEtLjA0LS4yNy0uMTItLjUtLjIzLS43LS4xMS0uMi0uMjYtLjM2LS40NS0uNDlzLS40My0uMTktLjcyLS4xOS0uNTMuMDYtLjczLjE5LS4zNS4zLS40Ni41Yy0uMTEuMjEtLjIuNDQtLjI1LjctLjA1LjI2LS4wNy41My0uMDcuOHMuMDIuNTQuMDYuODEuMTMuNTEuMjQuNzNjLjExLjIxLjI2LjM4LjQ1LjUyeiIvPjxwYXRoIGQ9Ik0yMC4zMjUgMTIuNDJjLjE0Mi4wOC4zMDIuMTYuNDguMjM1cy4zNy4xNC41NzIuMTljLjIwMy4wNS40MTIuMDc2LjYyNS4wNzYuMTMyIDAgLjI3LS4wMS40MTItLjAzLjE0Mi0uMDIuMjY3LS4wNi4zNzQtLjEycy4xOTYtLjE0LjI2Ny0uMjRjLjA3LS4xLjEwNy0uMjMuMTA3LS4zOSAwLS4yOS0uMTE1LS41LS4zNDMtLjYzLS4yMy0uMTItLjU4LS4yMy0xLjAzLS4zMy0uMy0uMDYtLjU4LS4xNC0uODYtLjI0LS4yOC0uMS0uNTItLjIzLS43My0uNC0uMjItLjE3LS4zOS0uMzgtLjUxLS42My0uMTMtLjI1LS4xOS0uNTYtLjE5LS45M3MuMDgtLjY5LjI0LS45Ni4zOC0uNTEuNjUtLjdjLjI3LS4xOS41OC0uMzQuOTQtLjQzLjM1LS4xLjczLS4xNCAxLjExLS4xNC40IDAgLjc3LjAzIDEuMDkuMDkuMzIuMDYuNTkuMTQuODMuMjUuNDUuMTguNjguNDIuNy43MiAwIC4xNS0uMDUuMzMtLjE1LjU0cy0uMi40LS4zMi41OWMtLjExLS4wOC0uMjMtLjE2LS4zOC0uMjUtLjE1LS4wOC0uMzEtLjE3LS41LS4yNC0uMTgtLjA3LS4zNy0uMTQtLjU3LS4xOXMtLjQtLjA3LS42MS0uMDdjLS4xMSAwLS4yMy4wMS0uMzUuMDJzLS4yMy4wNS0uMzMuMDljLS4xLjA1LS4xOC4xMi0uMjUuMi0uMDcuMDktLjEuMi0uMS4zNSAwIC4zNS4zNy42IDEuMTEuNzYuMy4wNi42LjE0LjkuMjQuMy4xLjU3LjIzLjgxLjQxcy40My4zOS41OC42NmMuMTUuMjYuMjIuNTkuMjIuOTkgMCAuNDEtLjA4Ljc3LS4yMyAxLjA4LS4xNi4zMS0uMzguNTgtLjY1Ljc5cy0uNi4zOC0uOTcuNDljLS4zNy4xMi0uNzguMTctMS4yMi4xNy0uNDUgMC0uODMtLjAzLTEuMTQtLjFzLS41Ny0uMTQtLjc3LS4yM2MtLjE0LS4wNi0uMy0uMTUtLjQ3LS4yNy0uMTctLjEyLS4yNS0uMjgtLjI1LS40OCAwLS4xNy4wNS0uMzUuMTUtLjU0LjEtLjE5LjIyLS4zOS4zNS0uNTkuMDkuMDkuMjEuMTcuMzQuMjd6bTYuNDk2LTguMTQ1Yy42IDAgMS4wOC40ODMgMS4wOCAxLjA3OHMtLjQ4IDEuMDc3LTEuMDggMS4wNzctMS4wNy0uNDgtMS4wNy0xLjA3NWMwLS41OTYuNDktMS4wNzggMS4wOC0xLjA3OHptLS45NyAyLjY1NWMuMDMtLjAxLjEyLS4wMjcuMjYtLjA0LjE0LS4wMTcuMjktLjAyNS40NS0uMDI1cy4zMy4wMTUuNDkuMDQ2Yy4xNy4wMy4zMS4wOS40NC4xOHMuMjQuMjEuMzIuMzcuMTIuMzcuMTIuNjJ2Ni4xNmMtLjA0LjAyLS4xMy4wNC0uMjcuMDUtLjE0LjAxLS4yOS4wMi0uNDUuMDItLjIgMC0uMzgtLjAyLS41NS0uMDUtLjE2LS4wMy0uMy0uMS0uNDItLjJzLS4yMS0uMjItLjI3LS4zOWMtLjA2LS4xNi0uMS0uMzctLjEtLjYydi02LjF6bTMuMDUtMi4yNzdsLjIzLS4wM2MuMDctLjAxLjE1LS4wMTguMjMtLjAyMy4wOC0uMDA0LjE3LS4wMDYuMjUtLjAwNi4xNyAwIC4zMy4wMTUuNDkuMDQ2cy4zMS4wOTMuNDUuMTg0LjI0LjIxNi4zMi4zNzQuMTIuMzYyLjEyLjYxN3YxLjA2OGgyLjE0VjguNDRoLTIuMTR2My4yNjVjMCAuNzEyLjI5IDEuMDY4Ljg3IDEuMDY4LjE0IDAgLjI4LS4wMjMuNDEtLjA3LjEzLS4wNDUuMjQtLjA5Ni4zNS0uMTUuMS0uMDU3LjE5LS4xMTYuMjctLjE3Ni4wOC0uMDYuMTMtLjEwNy4xNi0uMTM3LjE2LjIyNC4yNy40MTcuMzUuNTguMDkuMTYyLjEzLjMxNC4xMy40NTYgMCAuMTMyLS4wNS4yNjItLjE2LjM5cy0uMjYuMjQzLS40NS4zNWMtLjE5LjEwNy0uNDMuMTkzLS43LjI2LS4yNy4wNjUtLjU3LjA5OC0uOS4wOTgtLjYzIDAtMS4xMi0uMTIyLTEuNDctLjM2NnMtLjYtLjU2NC0uNzQtLjk2Yy0uMDctLjIwNS0uMTItLjQxOC0uMTQtLjY0Mi0uMDItLjIyNC0uMDMtLjQ0Ny0uMDMtLjY3di03LjA4em02LjkgNi4yMzdjLjA0LjU2LjIyIDEuMDMuNTIgMS40LjMxLjM3Ljc5LjU1NyAxLjQ1LjU1Ny4yNiAwIC40OC0uMDI4LjY3LS4wODRzLjM3LS4xMjUuNTItLjIwN2MuMTUtLjA4LjI5LS4xNy40LS4yNjZsLjMxLS4yN2MuMTIuMTUuMjUuMzQ3LjM4LjU4NnMuMi40MzQuMi41ODZjMCAuMjI1LS4xMy40MjgtLjM4LjYxLS4yMS4xNjQtLjUxLjMwMy0uOS40Mi0uMzkuMTE3LS44NS4xNzYtMS4zOC4xNzYtLjQ4IDAtLjk1LS4wNi0xLjQxLS4xODItLjQ2LS4xMi0uODctLjMzNC0xLjIzLS42NHMtLjY1LS43MTMtLjg3LTEuMjI3Yy0uMjItLjUyLS4zMy0xLjE3LS4zMy0xLjk1IDAtLjY0LjEtMS4xOS4zLTEuNjZzLjQ2LS44NS43OS0xLjE1Yy4zMy0uMzEuNy0uNTMgMS4xMi0uNjhzLjg1LS4yMiAxLjI4LS4yMmMuNTcgMCAxLjA1LjA5IDEuNDUuMjcuNC4xOC43Mi40MS45Ny43MXMuNDMuNjQuNTQgMS4wM2MuMTEuMzguMTcuNzkuMTcgMS4yMnYuMjFsLS4wMS4yNi0uMDEuMjZzLS4wMS4xNS0uMDIuMmgtNC41em0yLjY2LTEuMTRjMC0uNDktLjA5LS44ODQtLjI4LTEuMTlzLS41Mi0uNDYtMS4wMS0uNDZjLS40MSAwLS43NS4xNDgtMSAuNDM4cy0uMzcuNjk0LS4zNyAxLjIxMmgyLjY3em0zLjM3IDIuNjdjLjE0LjA4LjMxLjE2LjQ4LjIzNy4xOC4wNzYuMzcuMTQuNTguMTkuMjEuMDUuNDEuMDc2LjYzLjA3Ni4xNCAwIC4yNy0uMDEuNDItLjAzLjE1LS4wMi4yNy0uMDYuMzgtLjEyLjExLS4wNi4yLS4xNDQuMjctLjI0NnMuMTEtLjIzNC4xMS0uMzk2YzAtLjI5LS4xMS0uNS0uMzQtLjYzLS4yMy0uMTItLjU3LS4yMy0xLjAzLS4zMy0uMjktLjA2LS41Ny0uMTQtLjg1LS4yNC0uMjctLjEtLjUyLS4yMy0uNzMtLjQtLjIxLS4xNy0uMzgtLjM4LS41MS0uNjNzLS4xOS0uNTYtLjE5LS45My4wOC0uNjguMjQtLjk2Yy4xNy0uMjcuMzgtLjUxLjY1LS43LjI3LS4xOS41OC0uMzMuOTQtLjQzcy43My0uMTQgMS4xMS0uMTRjLjQxIDAgLjc3LjAzIDEuMDkuMDkuMzIuMDYuNi4xNS44My4yNS40NS4xOS42OS40Mi43MS43MiAwIC4xNi0uMDUuMzQtLjE0LjU0cy0uMi40MS0uMzEuNTljLS4xLS4wOC0uMjItLjE2LS4zNy0uMjVzLS4zMS0uMTctLjQ5LS4yNGMtLjE4LS4wNy0uMzctLjE0LS41Ny0uMTktLjItLjA1LS40LS4wNy0uNi0uMDctLjExIDAtLjIzLjAxLS4zNS4wM3MtLjIzLjA1LS4zMy4wOWMtLjEuMDUtLjE4LjExLS4yNC4yLS4wNi4wOC0uMS4yLS4xLjM0IDAgLjM1LjM3LjYgMS4xMi43Ni4zLjA2LjYxLjE0LjkxLjI0LjMuMS41Ny4yMy44MS40MXMuNDMuMzkuNTguNjYuMjIuNi4yMi45OWMwIC40MS0uMDguNzctLjI0IDEuMDktLjE2LjMyLS4zOC41OC0uNjUuNzlzLS42LjM4LS45Ny40OWMtLjM3LjEyLS43Ny4xNy0xLjIxLjE3LS40NSAwLS44My0uMDMtMS4xNC0uMXMtLjU2LS4xNC0uNzctLjIzYy0uMTQtLjA2LS4zLS4xNS0uNDYtLjI3LS4xNy0uMTEtLjI1LS4yNy0uMjUtLjQ4IDAtLjE3LjA1LS4zNS4xNS0uNTQuMS0uMTkuMjItLjM4LjM1LS41OS4wOS4wOS4yMS4xNy4zNC4yNnptNS41NS01LjQ5bC4xOS0uMDNjLjA2LS4wMS4xNC0uMDIuMjItLjAyMy4wOC0uMDA1LjE4LS4wMDguMjktLjAwOC4zNCAwIC42Mi4wNS44Ni4xNnMuMzguMy40NC41NmMuMTctLjIuNDItLjM5Ljc3LS41OXMuNzktLjMgMS4zMS0uM2MuMzggMCAuNzQuMDYgMS4wOC4xOXMuNjQuMzMuOTEuNjIuNDguNjYuNjMgMS4xM2MuMTYuNDcuMjQgMS4wNC4yNCAxLjcyIDAgLjc5LS4wOSAxLjQ0LS4yNyAxLjk2LS4xOC41MS0uNDIuOTItLjcxIDEuMjJzLS42MS41MS0uOTYuNjMtLjcxLjE4LTEuMDYuMThjLS4zIDAtLjU1LS4wNC0uNzctLjEtLjIyLS4wNy0uNC0uMTQtLjU2LS4yMi0uMTUtLjA4LS4yNy0uMTctLjM1LS4yNS0uMDgtLjA5LS4xMy0uMTQtLjE1LS4xN3YyLjNINDcuNHYtOXptMi4wOCA1LjM1Yy4wOS4wOC4yMy4xOC40NC4yOS4yMS4xMS40NS4xNy43My4xNy41MiAwIC45LS4yMDIgMS4xNS0uNjFzLjM3LS45NzUuMzctMS43MWMwLS4zMDQtLjAzLS41OS0uMDgtLjg1M3MtLjEzLS40OTMtLjI1LS42ODYtLjI3LS4zNC0uNDctLjQ1Yy0uMi0uMTEtLjQ0LS4xNi0uNzItLjE2LS40MiAwLS43Mi4wOC0uODkuMjUtLjE3LjE3LS4yNS4zNC0uMjUuNTR2My4yM3ptNy42Ni0xLjM5Yy4wNC41Ni4yMiAxLjAzLjUyIDEuNC4zMS4zNy43OS41NTUgMS40NS41NTUuMjYgMCAuNDgtLjAyNi42Ny0uMDgycy4zNy0uMTIyLjUyLS4yMDRjLjE1LS4wOC4yOS0uMTcuNC0uMjdsLjMxLS4yN2MuMTIuMTUuMjUuMzUuMzguNTlzLjIuNDMuMi41OGMwIC4yMi0uMTMuNDMtLjM4LjYxLS4yMS4xNi0uNTEuMy0uOTEuNDJzLS44NS4xNy0xLjM4LjE3Yy0uNDggMC0uOTUtLjA2LTEuNDEtLjE5LS40Ni0uMTMtLjg3LS4zNC0xLjIzLS42NC0uMzYtLjMxLS42NS0uNzItLjg4LTEuMjMtLjIyLS41MS0uMzMtMS4xNi0uMzMtMS45NSAwLS42NC4xLTEuMTkuMy0xLjY2LjItLjQ3LjQ2LS44NS43OS0xLjE1LjMzLS4zMS43LS41MyAxLjEyLS42N3MuODQtLjIyIDEuMjgtLjIyYy41NyAwIDEuMDUuMDkgMS40NS4yNnMuNzIuNDEuOTcuNzEuNDMuNjQuNTQgMS4wM2MuMTEuMzguMTcuNzkuMTcgMS4yMnYuMjFsLS4wMS4yNi0uMDIuMjZjMCAuMDktLjAxLjE1LS4wMi4yMWgtNC41em0yLjY1LTEuMTRjMC0uNDktLjA5LS44ODItLjI4LTEuMTlzLS41Mi0uNDU0LTEuMDEtLjQ1NGMtLjQxIDAtLjc1LjE0NS0xIC40MzVzLS4zNy43LS4zNyAxLjIxaDIuNjd6bTQuNTggMS4xNDdjLjA0LjU2LjIyIDEuMDI0LjUyIDEuMzk1LjMxLjM3Ljc5LjU1NCAxLjQ1LjU1NC4yNiAwIC40OC0uMDI4LjY3LS4wODRzLjM3LS4xMjUuNTItLjIwN2MuMTUtLjA4LjI5LS4xNy40LS4yNjdsLjMxLS4yNjhjLjEyLjE1Mi4yNS4zNDcuMzguNTg2LjE0LjIzOC4yLjQzNC4yLjU4NiAwIC4yMjYtLjEzLjQzLS4zOC42MS0uMjEuMTY1LS41MS4zMDQtLjkuNDItLjM5LjExOC0uODUuMTc2LTEuMzguMTc2LS40OCAwLS45NS0uMDYtMS40MS0uMTgzLS40Ni0uMTIyLS44Ny0uMzM2LTEuMjMtLjY0LS4zNi0uMzA1LS42NS0uNzE0LS44Ny0xLjIyOC0uMjItLjUxNC0uMzMtMS4xNjMtLjMzLTEuOTQ2IDAtLjY0LjEtMS4xOS4zLTEuNjUuMi0uNDYuNDctLjg0LjgtMS4xNS4zMy0uMy43LS41MyAxLjEyLS42N3MuODQtLjIxIDEuMjgtLjIxYy41NyAwIDEuMDUuMDkgMS40NS4yNy4zOS4xOC43Mi40Mi45Ny43MnMuNDMuNjUuNTUgMS4wM2MuMTEuMzkuMTYuOC4xNiAxLjIydi4yMnMwIC4xNy0uMDEuMjZsLS4wMS4yN2MtLjAxLjA5LS4wMS4xNi0uMDIuMjFINjQuNHYuMDF6TTY3IDkuNzU0YzAtLjQ4Ny0uMDk0LS44ODQtLjI4LTEuMTktLjE5LS4zMDQtLjUyOC0uNDU2LTEuMDE2LS40NTYtLjQxNiAwLS43NS4xNDUtMSAuNDM1cy0uMzcyLjY5NC0uMzcyIDEuMjFINjd6bTcuNDQtMS4wMDRjLS4wOC0uMDgtLjIyLS4xOC0uNDItLjI5LS4yLS4xMTQtLjQzLS4xNy0uNjk1LS4xNy0uNTMgMC0uOTIuMTkyLTEuMTguNTgtLjI1My4zODUtLjM4Ljk0LS4zOCAxLjY2IDAgLjM1Ni4wMjYuNjguMDc2Ljk3LjA1LjI5LjE0LjUzNC4yNi43NC4xMy4yLjI5LjM2LjQ5LjQ3LjIxLjExLjQ3LjE2Ni43OC4xNjYuMyAwIC41NS0uMDYuNzYtLjE4M3MuMzItLjI5My4zMi0uNTE2di0zLjQzem0uNzE1IDUuMzk2Yy0uMTc3IDAtLjMxLS4wNi0uNDE2LS4xNzUtLjEtLjExLS4xNS0uMjYtLjE1LS40NS0uMTQuMTgtLjM4LjM1LS43My41NC0uMzQuMTktLjc4LjI4LTEuMzEuMjgtLjM4IDAtLjc0LS4wNi0xLjA5LS4xOC0uMzUtLjEyLS42Ni0uMzItLjk0LS42MXMtLjQ5LS42Ni0uNjYtMS4xM2MtLjE2LS40Ny0uMjUtMS4wNi0uMjUtMS43NnMuMDgtMS4zLjI1LTEuOGMuMTctLjUuMzktLjkuNjctMS4yMXMuNi0uNTQuOTYtLjY4Ljc0LS4yMiAxLjE0LS4yMmMuNDUgMCAuODMuMDggMS4xMy4yNC4yOS4xNi41MS4zMi42NS40N1Y0LjYxYy4wNy0uMDIuMTgtLjAzNi4zMi0uMDQ3LjE0LS4wMS4yNy0uMDE0LjM4LS4wMTQuMTYgMCAuMzMuMDEuNS4wNHMuMzIuMDkuNDUuMTguMjQuMjEuMzEuMzdjLjA4LjE2LjExLjM2LjExLjYydjguMzdoLTEuMzV6bTIuNTktLjA1NmMtLjItLjIyLS4zLS40OS0uMy0uODEycy4xMDQtLjU4NC4zMTUtLjc5Yy4yMS0uMjA1LjQ3Ni0uMzA3Ljc5Ny0uMzA3cy41ODcuMTEuOC4zMWMuMjEuMjEuMzE1LjQ3LjMxNS43OSAwIC4zMi0uMS41OS0uMy44MS0uMi4yMi0uNDcuMzMtLjgxLjMzLS4zMy4wMS0uNi0uMS0uODEtLjMxem0yLjczNy03LjAyYy4wMy0uMDEuMTEtLjAyNC4yNDQtLjA0LjEzNS0uMDE0LjI4My0uMDIyLjQ0NC0uMDIycy4zMi4wMTUuNDguMDQ1LjMwNS4wODMuNDM1LjE3LjIzNS4yMDMuMzE1LjM2Yy4wOC4xNTQuMTIuMzYuMTIuNjF2Ni4wNzJjLS4wNC4wMi0uMTMuMDM1LS4yNy4wNDUtLjE0LjAxLS4yOS4wMTMtLjQ1LjAxMy0uMiAwLS4zOC0uMDE4LS41NC0uMDUzLS4xNi0uMDM2LS4zLS4xLS40MTctLjE5Ny0uMTItLjA5NS0uMjEtLjIyMy0uMjctLjM4My0uMDctLjE2LS4xLS4zNjYtLjEtLjYxNnYtNi4wMXptLS4wMDctMS42NGMwLS4zMi4xMDMtLjU4My4zMTQtLjc5LjIxLS4yMDQuNDctLjMxLjc4LS4zMS4zIDAgLjU2LjEwNi43Ny4zMS4yMS4yMDYuMzIuNDcuMzIuNzkgMCAuMzItLjExLjU4LS4zMi43OC0uMjIuMi0uNDguMy0uNzguMy0uMzEgMC0uNTgtLjEtLjc5LS4zLS4yMS0uMi0uMzEtLjQ2LS4zMS0uNzh6bTMuNzMgNy44NDhjLS4yOC0uMzUtLjQ4Ny0uNzU0LS42MTctMS4yMXMtLjE5NS0uOTM1LS4xOTUtMS40MzZjMC0uNTEuMDczLS45OTQuMjIzLTEuNDUuMTUzLS40NTYuMzc1LS44Ni42Ny0xLjIwMy4yOTctLjM1LjY3LS42MiAxLjEyLS44Mi40NS0uMi45NzgtLjMgMS41OC0uMy42MyAwIDEuMTcuMSAxLjYxNi4zLjQ0My4yLjgwNC40NyAxLjA4LjgxLjI3NC4zNC40NzQuNzMuNiAxLjE4LjEyMi40NS4xODUuOTIuMTg1IDEuNDJzLS4wNjQuOTgtLjE5IDEuNDRjLS4xMy40Ni0uMzM1Ljg2LS42MiAxLjIyLS4yODcuMzUtLjY1NS42My0xLjEwNi44NC0uNDUuMjEtLjk5LjMxLTEuNjQuMzFzLTEuMTgtLjExLTEuNjMtLjMxYy0uNDQtLjIxLS44MS0uNDgtMS4wOS0uODJ6bTEuOTg0LS42Yy4yLjEzLjQ0LjE5NC43My4xOTQuMyAwIC41NS0uMDY0Ljc0LS4xOTRzLjM1LS4zMDMuNDYtLjUyYy4xMS0uMjE0LjE4LS40NTcuMjItLjcyOHMuMDYtLjU0Ni4wNi0uODI3YzAtLjI3LS4wMi0uNTQtLjA2LS44MDQtLjA0LS4yNy0uMTItLjUtLjIzLS43LS4xMS0uMi0uMjYtLjM3LS40NS0uNDktLjE5LS4xMy0uNDMtLjE5LS43Mi0uMTlzLS41NC4wNi0uNzMuMTktLjM1LjMtLjQ3LjUtLjIuNDQtLjI1LjdjLS4wNS4yNi0uMDguNTItLjA4Ljc5cy4wMi41NC4wNy44MS4xMi41MS4yMy43M2MuMTEuMjEuMjYuMzguNDUuNTF6Ii8+PC9nPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTUuOTcgNC4wMWwuMjIzLS41ODUuMDAyLS4wMDRjLjEyLS4zNC4yNjctLjY4LjM3OC0xLjAzLjA5LS4yOC4xNjctLjYxIDAtLjg4LS4xNjgtLjI3LS40OTQtLjM0LS43OTUtLjM2LS40MjMtLjAyLS45MDQuMDUtMS4zMjMuMTFsLTEuNDEzLjJDMTEuODMyLjU1IDEwLjMzNy4wMiA4LjcxNi4wMlM1LjYuNTUgNC4zOSAxLjQ0NWwtMS40MTMtLjE5M2MtLjQyLS4wNTctLjktLjEyMi0xLjMyMy0uMTAyLS4zLjAxOC0uNjI3LjA4Ny0uNzk2LjM2LS4xNjYuMjctLjA5LjYgMCAuODguMTEyLjM1LjI1Ny42OS4zOCAxLjAzNXYuMDA0bC41OSAxLjU0Yy0uMjQ1LjcyLS4zNzggMS41LS4zNzggMi4zMSAwIDEuNDEuNDEgMi43NCAxLjM1NCAzLjgyLjA5My4xLjE5LjIuMjkuM2wtLjAwNS4wMmMtLjQ3LjA1LS45NC0uMTYtMS4yMi0uNTgtLjA0LS4wNi0uMDYtLjE2LS4wNy0uMjItLjAzLS4xMS0uMDctLjItLjEzLS4yOS0uMjctLjQyLS44My0uNTQtMS4yNS0uMjctLjQ4LjMxLS40OS44MS0uMjYgMS4yOC4wNS4xMS4xMS4yMi4xOC4zMi42NSAxIDEuODQgMS40NSAyLjk0IDEuMTkuMDQuMTMuMDkuMjUuMTQuMzYtLjE5LjAzLS4zOS4wMy0uNTYtLjAxbC0uMjMtLjA1LS4wOS4yMWMtLjE4LjQ0LS4yNi45MS0uMjIgMS4zOGwuMDIuMiAxLjAyIDEuMTktLjA1LjAyLS40Mi4xNS4yOC4zMmMuMDMuMDQuMDcuMDguMS4xMkw0LjMgMTcuOWwuMDMuMDMuMDI1LjAzLjAzLjAzLjAzLjAzLjAzLjAzLjAzLjAzLjAzLjAzLjAzMy4wMy4wMzQuMDMuMDMuMDMuMDMzLjAzLjAzNS4wMjMuMDM3LjAzLjAzNS4wMy4wMzQuMDMuMDM0LjAyNS4wMzcuMDMuMDM2LjAzLjA0LjAzLjAzMi4wMjIuMDQuMDMuMDM0LjAyNi4wNC4wMjIuMDQuMDI3LjA0LjAyNy4wNC4wMjUuMDQuMDI0LjA0LjAzLjA0LjAyLjA0LjAyLjA2LjAzLjEzLjA3LjA1LjAzLjE3LS4xOC4wMi0uMDIuMDItLjAyLjAzLS4wMi4wMi0uMDIuMDMtLjAyLjAzLS4wMi4wMy0uMDIuMDMtLjAyLjAzLS4wMS4wMy0uMDEuMDQtLjAxLjA0LS4wMS4wMy0uMDEuMDQtLjAxLjA0LS4wMS4wNC0uMDFoLjA0bC4wNC0uMDEuMDQtLjAxaC4zbC4wNC4wMS4wNC4wMS4wNC4wMS4wNC4wMS4wNC4wMS4wMi4wMDcuNDguOTguMjEuMDNoLjA2bC4wNi4wMWguMDZsLjA1LjAxaC4yM2wuMDUuMDEuMDUuMDFoLjg4NWwuMDYtLjAwN2guMTFsLjA2LS4wMS4wNi0uMDA4LjA2LS4wMDIuMDU1LS4wMS4wNi0uMDEuMDYtLjAxLjA2LS4wMDUuMDYtLjAxLjA2LS4wMS4yMi0uMDMuNDctLjk0Yy4wNC0uMDMuMDgtLjA0LjEyLS4wNmwuMDUtLjAxaC4wNGwuMDUtLjAxLjA0LS4wMS4wNC0uMDA0aC4xM2wuMDQuMDFIMTFsLjA0NC4wMS4wNC4wMDUuMDQuMDEuMDQuMDA1LjA0LjAxLjA0LjAxLjA0LjAxLjAzNy4wMTIuMDQuMDE1LjA0LjAxLjA0LjAyLjAzLjAxLjAzLjAyLjAzLjAyLjAzLjAyLjAzLjAyLjAzLjAyLjAyLjAyLjAyLjAyLjE4LjE5LjA1LS4wMy4xMy0uMDcuMDYtLjAzLjA1LS4wMi4wNC0uMDMuMDUtLjAyLjA0LS4wMi4wNC0uMDIyLjA0LS4wMjUuMDQtLjAyLjA0LS4wMjcuMDMtLjAyLjA0LS4wMi4wNC0uMDI0LjAzLS4wMy4wNC0uMDMuMDQtLjAzLjAzLS4wMy4wNC0uMDIuMDQtLjAzLjAzNi0uMDIuMDMtLjAzLjAzLS4wMy4wMy0uMDMuMDM2LS4wMy4wMy0uMDMuMDMtLjAyNy4wMy0uMDMuMDMtLjAzLjAzLS4wMy4wMy0uMDMuMDMtLjAzLjAzLS4wMyAxLjAzLTEuMTRjLjA0LS4wMy4wNy0uMDcuMTEtLjExbC4yOC0uMzItLjQyLS4xNWMtLjAyLS4wMS0uMDQtLjAxLS4wNS0uMDJsMS4wMi0xLjE4Ny4wMi0uMi4wMS0uMTRjLjc4LjI2IDEuNjYuMzUgMi4yNi4xLjAyLS4wMS4wNC0uMDIuMDUtLjA0LjQ0NC0uMjEuNzE1LS42NC44My0xLjExLjEzLS41LjA5LTEuMDU2LS4wOC0xLjU0Ni0uMTMtLjQxLS4zNi0uOC0uNjktMS4wODUtLjMtLjI2LS42OC0uNDQtMS4wOC0uNDEtLjAzIDAtLjA2IDAtLjA5LjAxbC0uMjctLjUzYy44NC0uNzYgMS4zMy0xLjg0IDEuMzMtMi45OCAwLTEuMjItLjU0LTIuMzEtMS40LTMuMDR6bS0xLjI0NiA2Ljk4Yy4wNTUtLjA2NS4xMDgtLjEzMi4xNi0uMmwuMzIzLjYzNWMtLjA1OC4wMzYtLjEyLjA1OC0uMTcyLjA0Ny0uMTU4LS4wMzItLjI2Ni0uMzE2LS4zMS0uNDh6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNGRkYiIGQ9Ik0xLjU4MiAxMS4wNDRjLjMzLjUxMi45Ljc3NiAxLjQ2OC43NDIuMDA1LjIzOC4wNTguNS4xMzMuNzU3LS45NS4yMDYtMS45NzMtLjE4LTIuNTMyLTEuMDQ2LS4yMS0uMzMzLS40Ni0uODM0LS4wMi0xLjEyLjI2LS4xNjUuNi0uMDkyLjc2LjE2NC4xLjE2LjA5LjM0LjIuNTF6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiM2Rjk0MjYiIGQ9Ik0xMy43MDggMTYuMTU1bDEuMDgzLTEuMjQ0Yy0uMjgtLjA1LS41OS0uMDQtLjg3LjA2LS4yNy4xLS41Ny4zMS0uNTcuNjMuMDEuMjQuMTcuNDMuMzYuNTd6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNEQ0IwMDAiIGQ9Ik0xMy4yNTUgMTcuMzM2Yy0uMzMzLjM5OC0uNjYyLjc0LTEuMTEgMS4wMmwuNTQ0LS42ODRjLjE5LS4xMDUuMzgtLjIxMy41Ni0uMzM2em0tNy45NTcgMS4wMmMtLjQzNi0uMjgyLS43NDgtLjYyNC0xLjEwNi0xLjAyLjE4Mi4xMjMuMzcuMjMuNTY0LjMzNmwuNTQyLjY4M3ptLjI3Ni4xNjJsLS43NC0uOTNjLjM1LS4zODQuOTg0LS41MSAxLjUtLjQybC41MjYuOTcyLS4wMS0uMDAyYy0uNDUtLjA2Mi0uOTU0LjA0My0xLjI3Ni4zOHptLjkzLTEuMzE0Yy40MjIuMTI0Ljk1LjUyLjcxMyAxLjA0Mi0uMDY1LS4wMy0uMTMtLjA1Mi0uMi0uMDcybC0uNTE0LS45N3ptMy42MDggMS4yNTNsLS4zMzIuNzE3Yy0uNy4wOS0xLjQxNC4wOS0yLjExNCAwbC0uMzMyLS43MTdjLjkwOC4xMiAxLjg3LjEyIDIuNzc4IDB6bS4yNS0uMjYyYy0uMDQ1LjAxNC0uMDkuMDMyLS4xMy4wNS0uMjE2LS40Ny4yMDUtLjg2OC42MjgtMS4wMTRsLS41Ljk3em0xLjUxLjMyMmMtLjMzNS0uMzUtLjg2LS40NS0xLjMyNS0uMzdsLS4wMTUuMDAzLjUtLjk2OGMuNTMtLjExOCAxLjIxIDAgMS41OC40MDNsLS43NC45MzJ6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNCQTAwMDAiIGQ9Ik0zLjc0IDE2LjE1NUwyLjY1NSAxNC45MWguMDA0Yy4yOC0uMDUzLjU5LS4wNC44Ny4wNTIuMjcuMDkzLjU3LjMwNS41Ny42MjUtLjAxLjIzNS0uMTcuNDMtLjM2LjU2OHoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iIzlDMyIgZD0iTTEzLjc4NSAxNi43M2MuMDg3LS4wOC4xNjgtLjE2NS4yNDQtLjI1LS42NS0uMjI4LS45OC0uNzM3LS43Ni0xLjE4LjIxLS40MzMuODgtLjY1MyAxLjU0LS41MyAwLS4wNzMuMDEtLjE0NS4wMS0uMjE4LS41MS0uMjA0LS45NS0uNDc2LTEuMTktLjc2LS4xNC0uMTU4LS4yNS0uMzI2LS4zNS0uNTAzLS4wNy0uMDUtLjEzLS4wOS0uMTgtLjE0LS4zNy40NC0uNzcuODItMS4yIDEuMTNsLS4wMS4wMWMtLjEuMTktLjIxLjM5LS4zNC41OC0uMDYuMjItLjE3LjQyLS4zNC42MWwyLjU1IDEuMjR6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNGMDAiIGQ9Ik0zLjU1MiAxMy41MTVjLS4yMzcuMDQ1LS40ODguMDQ4LS43MjUuMDAzLS4xNjguNDEzLS4yMzIuODM2LS4xOTQgMS4yNS42NjItLjEyMiAxLjMzMy4wOTggMS41NDQuNTMyLjIxNi40NDMtLjExNy45NTItLjc2IDEuMTc4LjEuMTE0LjIxLjIyNS4zMy4zM2wyLjUzNi0xLjI0NWMtLjE4OC0uMTk0LS4zMjMtLjQxMi0uMzktLjY0Ni0uMDMtLjA0LS4wNTYtLjA4LS4wODItLjEyMi0uMTguMTUtLjQ0LjE3Ny0uNjkuMTUtLjgxLS4wODUtMS4yLS42My0xLjUxLTEuMzE1bC0uMDUtLjExNXoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0ZDMCIgZD0iTTguNzI0IDE4LjM5NGMuNDYuMDA4LjkyNC0uMDE4IDEuMzgyLS4wOC0uMjM0LS40OTcuMDkyLTEuMDMyLjc2Ny0xLjIzNy42NjctLjIwMyAxLjQ1NS0uMDE3IDEuODQ4LjQxNy4zNi0uMTkzLjY3LS40MS45NC0uNjQ0bC0yLjU0LTEuMjM2Yy0uNTIuNS0xLjM5LjgzLTIuMzkuODMtLjk1IDAtMS43OS0uMjk3LTIuMzEtLjc1OGwtMi41MiAxLjI0Yy4yNS4yMDYuNTMuMzk2Ljg1LjU2OC40LS40MzMgMS4xOC0uNjIgMS44NS0uNDE3LjY4LjIwNSAxIC43NC43NyAxLjIzOC40Ni4wNi45Mi4wODYgMS4zOC4wOHoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iIzAwOTVEMiIgZD0iTTQuMTk1IDEyLjI0N2MyLjMzIDMuNTU3IDYuNzEzIDMuNTU3IDkuMDQzIDAtMS4zNC43OTctMi45NzggMS4xMDUtNC41MiAxLjEwNXMtMy4xODMtLjMxLTQuNTIzLTEuMTA1eiIvPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBmaWxsPSIjMDA1MTdDIiBkPSJNNC4xOTQgMTIuMjQ2YzEuMTI0IDEuNzE2IDIuNzI1IDIuNjA1IDQuMzQ0IDIuNjY2LjEtLjAwNC4yMDItLjAxLjMwMy0uMDItMS4zNi0uMTQtMi42OS0uODY3LTMuNzEtMi4xODQtLjMyLS4xMy0uNjMtLjI4NS0uOTMtLjQ2MnoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0ZGRiIgZD0iTTguNzE2LjQ1MmMxLjUyIDAgMi45MjcuNDk4IDQuMDYyIDEuMzRsMS4wODQtLjFjLjQ4Mi0uMDY2Ljk2NS0uMTQzIDEuNDUtLjE3NyAxLjQ2LS4xMDIgMS4wMzYuNDEuNTUgMS43OWwtLjE4NC40NzhjLS4yNy0uMTktLjU2Mi0uMzQ4LS44NzQtLjQ2Ny0uMDg0LS4xMy0uMTczLS4yNTUtLjI2NS0uMzc4LjAzLS4wNC4wNi0uMDguMDktLjExNy40NC0uNS45Ni0uODUgMS40OC0xLjAyLS45Mi0uMDctMS41Ny42LTIuMDMgMS4yN2wuMDUuMDdjLS4yNS0uMDUtLjUxLS4wNy0uNzctLjA3LTIuMjEgMC00LjAxIDEuOC00LjAxIDQuMDFzMS43OSA0LjAxIDQgNC4wMWMuMjYgMCAuNTItLjAyLjc4LS4wNy0xLjI1IDEuMy0zLjIyIDEuOTQtNS40MyAxLjk0LTMuNzggMC02Ljg0LTEuODYtNi44NC01LjYzIDAtMS42LjU1LTMuMDggMS40OC00LjI1LS40My0uNjctMS4xMy0xLjM5LTIuMDUtMS4yNS41MS4xNyAxLjAzLjUzIDEuNDcgMS4wM2wuMS4xMmMtLjM1LjQ3LS42NS45OC0uODggMS41M2wtLjQ0LTEuMThjLS40OC0xLjM2LS45LTEuODguNTEtMS43OS40NC4wMy44Ny4wOSAxLjMxLjE1LjQyLjA3Ljg0LjEgMS4yNi4xM0M1Ljc5Ljk1IDcuMTkuNDUgOC43MS40NXptNC42NTQgNC4wMTJjLTEuNDMgMC0yLjU5IDEuMTYtMi41OSAyLjU5IDAgMS40MzIgMS4xNiAyLjU5MiAyLjU5IDIuNTkyczIuNTktMS4xNiAyLjU5LTIuNTljMC0xLjQzMi0xLjE2LTIuNTkyLTIuNTktMi41OTJ6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNFN0U4RTkiIGQ9Ik02LjMxMyAxMi42MzdjLTIuNTg4LS42NS00LjQzLTIuNDI2LTQuNDMtNS4zNTMgMC0uNjMyLjA4Ni0xLjI0NC4yNDctMS44MjUuMjQ4LS44OC42NjUtMS43MSAxLjIzMi0yLjQybC4wMDMtLjAxYy0uNDM3LS42Ny0xLjEzNy0xLjM5LTIuMDQ4LTEuMjUuNTEuMTcgMS4wMzYuNTIgMS40NzggMS4wMy4wMzQuMDQuMDY3LjA3LjA5OC4xMS0uMzUuNDctLjY0Ni45OC0uODc2IDEuNTNMMS41NyAzLjNjLS40OC0xLjM2NS0uOTAyLTEuODgyLjUxLTEuNzkuNDM4LjAyNy44NzQuMDg4IDEuMzEuMTUuNDIzLjA2Ljg0LjA5NiAxLjI2Ny4xMjUuMDktLjA2Ny4xODMtLjEzMi4yNzctLjE5NC42NS0uNDMgMS4zOC0uNzUgMi4xNjItLjk0LTIuNDMzIDEuMTEtNC4xMzggMy42OC00LjEzOCA2LjY4IDAgMi42NiAxLjM0NyA0LjQzIDMuMzU1IDUuMzJ6Ii8+PHBhdGggZD0iTTkuNDQ2IDEwLjMzM2MuMjI0LjAzLjUzMi0uMTkzLjc0Ny0uMzUuMjUyLS4xODIuMjItLjA1OC4wNzIuMTItLjE5Mi4yMzYtLjQuNDktLjcxMi41NC0uMS4wMTYtLjE5NS4wMTItLjI4Mi0uMDAyLS4xMS0uMDEtLjIxLS4wNS0uMjctLjA4LS4xMy0uMDctLjI0LS4xLS4zNC0uMS0uMSAwLS4yLjA0LS4zNC4xMS0uMDYuMDQtLjE2LjA3LS4yNy4wOS0uMDguMDItLjE4LjAyLS4yOC4wMS0uMzEtLjA1LS41Mi0uMy0uNzEtLjU0LS4xNy0uMi0uMTUtLjI4LjA3LS4xMi4yMi4xNi41My4zOC43NS4zNS4yMi0uMDMuNDEtLjA3LjUzLS4xNS4xMS0uMDcuMTctLjE5LjEzLS4zOGwtLjAxLS4wNmMtLjM4LS4zNy0uNzgtLjI2LS45Mi0uNDktLjA3LS4xMy0uMDQtLjI1LjA1LS4zNi4zLS4zNyAxLjc1LS4zNyAyLjA1IDAgLjA5LjExLjEzLjI0LjA1LjM3LS4xMy4yMi0uNTIuMTItLjg4LjQ2IDAgLjA0LS4wMS4wNy0uMDEuMS0uMDQuMTkuMDEuMzEuMTIuMzl2LjAxYy4xMi4wOC4yOS4xMi41MS4xNXoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0YwMCIgZD0iTTE1LjY3OCA5Ljk2bC4zNDguNjgtLjA2Ni4wMjdjLS4yMzUuMTA4LS40Mi4yNzctLjU2NC40OGwtLjM5LS43NjNjLS40OTQuMjQzLTEuMDUuMzgtMS42MzcuMzgtMi4wNSAwLTMuNzEtMS42NjItMy43MS0zLjcxIDAtMi4wNSAxLjY2LTMuNzEgMy43MS0zLjcxIDIuMDQgMCAzLjcxIDEuNjYgMy43MSAzLjcxIDAgMS4xNzctLjU1IDIuMjI1LTEuNDEgMi45MDV6TTEzLjM3IDQuMTdjMS41OTMgMCAyLjg4NSAxLjI5IDIuODg1IDIuODg0IDAgMS41OTMtMS4yOTIgMi44ODUtMi44ODUgMi44ODUtMS41OTMgMC0yLjg4NS0xLjMtMi44ODUtMi44OXMxLjI5Mi0yLjg5IDIuODg1LTIuODl6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiM5QTAwMDAiIGQ9Ik0xNS4zOTYgMTEuMTQ4bC0uMzktLjc2M2MuMTAzLS4wNC4wMS4wMDUuMTEtLjA0NGwuMzY3LjctLjA4Ny4xMnptLTEuODQtLjM4OGMtLjA2LjAwMy0uMTIzLjAwNS0uMTg2LjAwNS0yLjA1IDAtMy43MS0xLjY2LTMuNzEtMy43MSAwLTIuMDQ4IDEuNjYtMy43MSAzLjcxLTMuNzEuMDYzIDAgLjEyNS4wMDIuMTg3LjAwNS00LjkwMy4yODgtNS4wODIgNy4wOTIgMCA3LjQxem0wLTYuNTg0YzEuNTA3LjA5NyAyLjcgMS4zNSAyLjcgMi44OCAwIDEuNTMtMS4xOTMgMi43ODItMi43IDIuODc4LjA2My4wMDQuMTI2LjAxNC4xODguMDA2IDMuNzA2LS40OTIgMy40NTMtNS40NzMgMC01Ljc3LS4wNjItLjAwNi0uMTI1LjAwMi0uMTg3LjAwNnoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0ZGRiIgZD0iTTE3Ljc3MyAxMi4xOTJjLjMwMi45LjA2IDEuODU1LS41NDMgMi4xMy0uNjAyLjI3Ny0xLjMzNS0uMjMtMS42MzctMS4xMy0uMzAyLS45LS4wNi0xLjg1NC41NDMtMi4xMy42MDItLjI3NiAxLjMzNS4yMyAxLjYzNyAxLjEzem0tMy40NDgtMS4wMTZjLjE0Ny40ODQuNDMuNzQuNzUzLjczLS4wOTQuNDctLjA0Ny45NzQuMTA0IDEuNDI1LjEzNy40MS4zNjcuOC42OSAxLjA5bC4wMzYuMDNjLTEuMjU0LS4xNC0yLjA3OC0uNzktMi40MjQtMS43OS4xODQtLjI2LjM1Ny0uNTUuNTE3LS44NWwuMjYtLjQ4LjA3LS4xNHoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0QxRDNENCIgZD0iTTE2LjQzOCAxNC4yODNjLS4zNTMtLjE4My0uNjctLjU3LS44NDUtMS4wOS0uMjktLjg2LS4wOC0xLjc3LjQ2NS0yLjA5LS4zNzQuNTItLjQ3IDEuMzc4LS4xOTUgMi4yLjEzMy4zOTcuMzM2LjczMi41NzUuOTh6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMy4zNyA1LjU1Yy4xIDAgLjIuMDEuMjk1LjAzLS4xNjIuMDgtLjI3NC4yNS0uMjc0LjQ0MyAwIC4yNzMuMjMuNDk1LjUuNDk1cy41LS4yMjIuNS0uNDk1di0uMDg4Yy4zMS4yNzUuNS42NzUuNSAxLjEyIDAgLjgzLS42NyAxLjUwNC0xLjUgMS41MDRzLTEuNS0uNjgtMS41LTEuNTEuNjgtMS41MSAxLjUxLTEuNTF6TTYuMDI4IDYuNjk2Yy43MTYuMTkyIDEuMjE4Ljc4NCAxLjMzIDEuNDctLjMzNC0uNDg1LS44MzYtLjg2LTEuNDUtMS4wMjQtLjYxNC0uMTY0LTEuMjM2LS4wOS0xLjc2OC4xNjMuNDQtLjU0IDEuMTcyLS44IDEuODg4LS42MXoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iIzAwOTVEMiIgZD0iTTE0LjMyNSAxMS4xNzZjLjExMi4zNy4zMDMuNjA1LjUzLjY5My0uMTcyLjAzLS44MTUgMS4yOS0uNzYgMS43Ny0uMjczLS4yNy0uNDc4LS42MS0uNjEtLjk5LjE4My0uMjcuMzU2LS41NS41MTYtLjg2bC4yNi0uNDkuMDctLjE0eiIvPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBmaWxsPSIjRkZGIiBkPSJNOS4yIDE1LjMyNmMuNTY4LjQ5OCAxLjI3NC4zMTYgMS45MS0uNTUzLS42MTQuMzA4LTEuMjYuNDkyLTEuOTEuNTUzem0tLjk2NiAwYy0uNTcuNDk4LTEuMjc1LjMxNi0xLjkxLS41NTMuNjEyLjMwOCAxLjI1Ny40OTIgMS45MS41NTN6bS0zLjA2Ny0uODFjLS42NjQtLjA3LS45MzYtLjU2NC0xLjE2Ny0xLjA2Ni0uMzEzLS42OC0uNDctMS4xOS0uNTEtMS41MzYuNTc1IDEuMDU2IDEuMzA3IDEuODY4IDIuMTI1IDIuNDM3LS4wNDIuMTMtLjE3My4yLS40NDguMTd6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMwMDk1RDIiIGQ9Ik00LjA1NiAxMy41N2MtLjAyLS4wNC0uMDM4LS4wOC0uMDU2LS4xMi0uMzEzLS42OC0uNDctMS4xOS0uNTEtMS41MzYuMzEzLjU3NC42NzIgMS4wNzYgMS4wNjYgMS41MDdsLS4wMTYuMDFjLS4xNS4wNy0uMzIuMTItLjQ4NC4xNXoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0JDQkVDMCIgZD0iTTIuODk0IDIuOTM3Yy0uMTk4LjI2NC0uMzc4LjU0My0uNTQuODM0LS4xODQtLjY5LS4zOS0xLjM1LS45My0xLjk0LjQ3Ny4xOS45Ni41MiAxLjM3Ljk5LjAzNS4wNC4wNjguMDguMS4xMnoiLz48L3N2Zz4=",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 9302
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 2.381999976933,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.33300000359305004,
+          "wait": 228.90000001643796,
+          "receive": 3.807999979471674,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.321Z",
+        "time": 235.50800001248717,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/arrow_down.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/arrow_down.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-length",
+              "value": "416"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "2.655ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"1a0-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/svg+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 416,
+            "mimeType": "image/svg+xml",
+            "text": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NS4zMzMiIGhlaWdodD0iMzguMDIxIiB2aWV3Qm94PSIwIDAgNjUuMzMzIDM4LjAyMSI+PHBhdGggZmlsbD0iIzlEOUQ5RCIgZD0iTTQzLjk1LjA0NmMtLjAzLjA0My0uMDYuMDg1LS4wODcuMTNsLTIuNTU2IDQuNDI1Yy02LjQxMyAxMS4wOS0xMi44MjcgMjIuMTc3LTE5LjI0IDMzLjI2NS0uMDI2LjA0Ni0uMDU0LjA5LS4wOS4xNTUtLjAzLS4wNDgtLjA1NC0uMDg0LS4wNzUtLjEyMmwtMTAuMDItMTcuMzQzQzcuOTU2IDEzLjc2IDQuMDMgNi45NjMuMTAyLjE2Ny4wOC4xMjUuMDUuMDg3LjAyMy4wNDcuMDI4LjAzNi4wMy4wMjMuMDM1LjAyM2MuMDMtLjAwMi4wNiAwIC4wOSAwaDQzLjcyM2MuMDM0IDAgLjA2OC4wMTQuMTAzLjAyMnoiLz48L3N2Zz4=",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 1016
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 2.16400000499561,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.26200001593680033,
+          "wait": 230.0070000055716,
+          "receive": 3.074999985983169,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.322Z",
+        "time": 235.66800000844523,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/logos/logoFooter.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/logos/logoFooter.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "2.677ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4027-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/svg+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 16423,
+            "mimeType": "image/svg+xml",
+            "text": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjMiIGhlaWdodD0iMjUuMzc1IiB2aWV3Qm94PSIwIDAgMTIzIDI1LjM3NSI+PGcgZmlsbD0iIzAyNEY3RCI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC43MzUgNS4xOTNsLjI5LS43Ni4wMDMtLjAwNWMuMTU4LS40NDcuMzQ3LS44OS40OS0xLjM0LjEyLS4zNjcuMjE4LS43OTQuMDAyLTEuMTQ1LS4yMi0uMzYtLjY0NC0uNDUtMS4wMzUtLjQ2OC0uNTUtLjAyNi0xLjE3Ni4wNTgtMS43Mi4xMzNsLTEuODQuMjUyQzE1LjM1Ni42OSAxMy40MSAwIDExLjMgMFM3LjI0NS42OSA1LjY3MyAxLjg1OGwtMS44MzctLjI1MmMtLjU0NS0uMDc0LTEuMTctLjE2LTEuNzIyLS4xMzItLjM5LjAyLS44MTQuMTA4LTEuMDM1LjQ2OC0uMjE2LjM1LS4xMTcuNzc4IDAgMS4xNDQuMTQ2LjQ1LjMzNS44OTQuNDkyIDEuMzRsLjAwMi4wMDYuNzY3IDIuMDAzYy0uMzE4Ljk0OC0uNDkgMS45NjItLjQ5IDMuMDE3IDAgMS44NDIuNTMgMy41NzIgMS43NiA0Ljk2OC4xMjIuMTM4LjI0OC4yNy4zOC4zOTdsLS4wMDguMDI3Yy0uNjA0LjA2Ni0xLjIyMi0uMjA0LTEuNTc1LS43NS0uMDQ3LS4wNzMtLjA3LS4yLS4wOTQtLjI4My0uMDM3LS4xMzItLjA4NS0uMjU1LS4xNi0uMzcyLS4zNTItLjU0NS0xLjA4LS43MDItMS42MjYtLjM1LS42MjUuNDA0LS42MyAxLjA2Mi0uMzQgMS42NzQuMDY4LjE0NS4xNS4yODQuMjM3LjQxOC44NDMgMS4zMDUgMi4zOSAxLjg4IDMuODIzIDEuNTUuMDYuMTY3LjEyMy4zMjcuMTg0LjQ3Mi0uMjUuMDM3LS41MDQuMDMzLS43Mi0uMDA4bC0uMjk4LS4wNTYtLjExNS4yOGMtLjIzMy41NzQtLjMzNSAxLjE4NS0uMjggMS44MDNsLjAyNS4yNjMgMS4zMjggMS41NDVjLS4wMjIuMDEtLjA0My4wMTctLjA2NS4wMjVsLS41NC4xOS4zNjYuNDE0LjE0LjE1MiAxLjM0IDEuNDg0LjAzNi4wNC4wMzcuMDM4LjA0LjA0LjAzNi4wNC4wNC4wNC4wNC4wMzcuMDQuMDM2LjA0Mi4wNC4wNC4wMzcuMDQzLjAzNy4wNDMuMDM3LjA0My4wMzcuMDQ1LjAzNi4wNDUuMDM2LjA0NS4wMzYuMDQ2LjAzNS4wNDguMDM2LjA0Ny4wMzUuMDQ4LjAzNC4wNS4wMzQuMDQ4LjAzNC4wNS4wMzQuMDUuMDMzLjA1Mi4wMzMuMDUuMDMyLjA1My4wMzIuMDUyLjAzLjA1NC4wMzIuMDU1LjAzLjA1NS4wMzQuMDcuMDM4LjE3LjA5NC4wNjUuMDM1LjIzLS4yNDIuMDMtLjAyOC4wMy0uMDI3LjAzNS0uMDI3LjAzNi0uMDI2LjAzNy0uMDI1LjA0LS4wMjQuMDQyLS4wMjMuMDQzLS4wMjIuMDQ1LS4wMi4wNDYtLjAyLjA0Ny0uMDIuMDUtLjAxNy4wNS0uMDE2LjA1LS4wMTQuMDUzLS4wMTMuMDUzLS4wMS4wNTQtLjAxLjA1NS0uMDEuMDU1LS4wMDUuMDU1LS4wMDUuMDU2LS4wMDNoLjExMmwuMDU2LjAwMi4wNTYuMDA0LjA1NS4wMDYuMDU1LjAwNy4wNTUuMDEuMDU0LjAxLjA1NC4wMTMuMDUzLjAxNS4wMjIuMDA3LjYyNiAxLjI2Ny4yOC4wMzYuMDcyLjAxLjA3NC4wMDguMDcyLjAwOC4wNzMuMDA3LjA3My4wMDguMDcyLjAwNi4wNzMuMDA2LjA3My4wMDUuMDczLjAwNC4wNzQuMDAzLjA3My4wMDMuMDczLjAwM2guMDczbC4wNzIuMDAzaC4wNzNsLjA3My4wMDJoLjQ0OGwuMDczLS4wMDIuMDczLS4wMDJoLjA3M2wuMDczLS4wMDQuMDcyLS4wMDQuMDczLS4wMDQuMDczLS4wMDQuMDczLS4wMDUuMDc0LS4wMDcuMDczLS4wMDYuMDczLS4wMDcuMDczLS4wMDcuMDczLS4wMDguMDczLS4wMDguMDctLjAxLjI4LS4wMzUuNjA2LTEuMjIyYy4wNDgtLjA1LjEtLjA2My4xNS0uMDhsLjA1NC0uMDEuMDU1LS4wMS4wNTUtLjAwOC4wNTUtLjAwNi4wNTYtLjAwNC4wNTctLjAwMmguMTEybC4wNTUuMDAzLjA1Ni4wMDUuMDU2LjAwNi4wNTUuMDA4LjA1NS4wMS4wNTMuMDEuMDUzLjAxNC4wNTMuMDE0LjA1LjAxNi4wNS4wMTcuMDQ3LjAyLjA0Ni4wMi4wNDUuMDIuMDQ0LjAyMi4wNDIuMDIzLjA0LjAyNC4wMzcuMDI1LjAzNi4wMjYuMDMzLjAyNy4wMy4wMjcuMDMuMDI4LjIzLjI0Mi4wNjQtLjAzNS4xNjctLjA5Mi4wNzMtLjA0LjA1NS0uMDMyLjA1NC0uMDMuMDUzLS4wMzIuMDUyLS4wMzIuMDUyLS4wMzIuMDUyLS4wMzMuMDUtLjAzNC4wNS0uMDMzLjA1LS4wMzMuMDUtLjAzNC4wNS0uMDM0LjA0Ny0uMDM1LjA0Ny0uMDM1LjA0Ny0uMDM1LjA0Ni0uMDM1LjA0NS0uMDM2LjA0NS0uMDM2LjA0NC0uMDM2LjA0My0uMDM3LjA0My0uMDM3LjA0My0uMDM4LjA0LS4wMzcuMDQzLS4wMzguMDQtLjAzOC4wNC0uMDQuMDQtLjAzOC4wMzctLjA0LjAzOC0uMDM4LjAzOC0uMDQuMDM2LS4wNCAxLjM0LTEuNDg1Yy4wNDYtLjA1LjA5My0uMS4xNC0uMTUzbC4zNjUtLjQxMy0uNTQtLjE5Yy0uMDIyLS4wMS0uMDQ0LS4wMTctLjA2NS0uMDI2bDEuMzI3LTEuNTQ1LjAyNC0uMjYyYy4wMDYtLjA2LjAxLS4xMi4wMTMtLjE4IDEuMDE2LjM0IDIuMTY4LjQ1NiAyLjk0OC4xMi4wMy0uMDEuMDUzLS4wMjguMDctLjA0OC41OC0uMjc1LjkzLS44NCAxLjA4NS0xLjQ0Ni4xNjctLjY1NS4xMTUtMS4zNzItLjEtMi4wMS0uMTc3LS41My0uNDc3LTEuMDM3LS44OTgtMS40MS0uMzktLjM0Ni0uODg0LS41Ny0xLjQxMy0uNTQtLjA0IDAtLjA4LjAwNS0uMTE4LjAxbC0uMzUzLS42OWMxLjA5Ny0uOTg1IDEuNzI3LTIuMzg2IDEuNzI3LTMuODczLjAwMi0xLjU4NC0uNzA3LTMuMDA0LTEuODI1LTMuOTZ6TTcuODAzIDguNjg3Yy45MzIuMjUgMS41ODUgMS4wMiAxLjczIDEuOTE0QzkuMSA5Ljk3IDguNDQ2IDkuNDggNy42NDggOS4yNjhjLS44LS4yMTQtMS42MDgtLjEyLTIuMy4yMS41NzMtLjcgMS41MjQtMS4wNCAyLjQ1NS0uNzl6bTkuNTUtMS40OWMuMTMyIDAgLjI2LjAxNC4zODUuMDM4LS4yMS4xMDYtLjM1Ni4zMjQtLjM1Ni41NzcgMCAuMzU2LjI4OC42NDQuNjQ0LjY0NC4zNTYgMCAuNjQ0LS4yODguNjQ0LS42NDQgMC0uMDQtLjAwMy0uMDc4LS4wMS0uMTE1LjQuMzU4LjY1Mi44NzguNjUyIDEuNDU3IDAgMS4wOC0uODc2IDEuOTU2LTEuOTU2IDEuOTU2UzE1LjQgMTAuMjM0IDE1LjQgOS4xNTRjLS4wMDItMS4wOC44NzQtMS45NTYgMS45NTQtMS45NTZ6bS01LjEwNCA2LjIyYy4yOS4wNC42OS0uMjUyLjk3LS40NTUuMzI4LS4yMzcuMjg1LS4wNzcuMDk1LjE1Ny0uMjUuMzA1LS41Mi42MzQtLjkyNi43LS4xMy4wMi0uMjU1LjAxNi0uMzY4LS4wMDItLjE0Ny0uMDI0LS4yNzQtLjA3LS4zNi0uMTE1LS4xNzUtLjA5Mi0uMzEyLS4xMzgtLjQ0NS0uMTM4cy0uMjcuMDQ2LS40NDYuMTM4Yy0uMDg0LjA0NC0uMjEuMDktLjM1OC4xMTUtLjExMy4wMTgtLjIzOC4wMjMtLjM2Ny4wMDItLjQwOC0uMDY2LS42NzctLjM5Ni0uOTI2LS43LS4yMi0uMjctLjE5NC0uMzY1LjA5My0uMTU3LjI4LjIwMy42OC40OTMuOTcuNDU0LjI4My0uMDM3LjUyNy0uMDkuNjg0LS4xOTYuMTQ1LS4wOTguMjE1LS4yNTIuMTY3LS41LS4wMDUtLjAyMy0uMDEtLjA1Mi0uMDEzLS4wODMtLjQ5LS40OS0xLjAxNi0uMzQ2LTEuMTk0LS42NC0uMS0uMTY1LS4wNTYtLjMzLjA2LS40NzUuMzk0LS40OCAyLjI3LS40OCAyLjY2MiAwIC4xMTcuMTQzLjE2LjMxLjA2LjQ3NS0uMTcyLjI4Ni0uNjcuMTU3LTEuMTUuNi0uMDA3LjA0OC0uMDEyLjA5Mi0uMDIuMTI0LS4wNDcuMjQ4LjAxMy40MDIuMTUuNSAwIC4wMDIgMCAuMDAzLjAwMi4wMDMuMTQ2LjEwNS4zNzguMTU3LjY2LjE5NHptLS4zMjIgNi40OTVjLjc0LjY0OCAxLjY1OC40MSAyLjQ4NS0uNzItLjc5Ny40LTEuNjM3LjY0LTIuNDg1Ljcyem0tMS4yNTUgMGMtLjc0LjY0OC0xLjY1OC40MS0yLjQ4NS0uNzIuNzk3LjQgMS42MzcuNjQgMi40ODUuNzJ6bTEyLjQxLTQuMDc2Yy4zOTIgMS4xNy4wNzYgMi40MTMtLjcwNyAyLjc3Mi0uNzgzLjM2LTEuNzM3LS4zLTIuMTMtMS40Ny0uMzkyLTEuMTctLjA3Ni0yLjQxMy43MDctMi43NzMuNzgyLS4zNiAxLjczNi4zIDIuMTMgMS40N3ptLTMuNzk3LS40MmMuMDkzLjAzNi4xOS4wNTMuMjkuMDUtLjEyMi42MS0uMDYyIDEuMjY1LjEzNSAxLjg1Mi4xOC41My40NzggMS4wMzcuOSAxLjQxbC4wNDYuMDRjLTEuMDAyLS4xMTMtMS43OTItLjQ3Ny0yLjM1OC0xLjA0LS4wNzItLjYyNC43NjQtMi4yNi45ODgtMi4zMTJ6TTYuNjg0IDE4Ljg2Yy0uNzk1LS4wODQtMS4xNTgtLjYzNi0xLjQ0NS0xLjIzMi4yMTItLjAzMy40MzQtLjEwMi42My0uMTkyaC4wMmMuNDMuNDcuODkzLjg3MiAxLjM3OCAxLjIxLS4wNTYuMTYzLS4yMjYuMjUtLjU4NC4yMTR6TTIuMDIgMTQuMzQzYy40My42NjYgMS4xNyAxLjAxIDEuOTEuOTY2LjAwNi4zMS4wNzYuNjUuMTcyLjk4My0xLjIzNy4yNjgtMi41NjYtLjIzNS0zLjI5My0xLjM2LS4yOC0uNDM0LS42MS0xLjA4Ni0uMDM1LTEuNDU4LjMzMi0uMjE1Ljc3Ni0uMTIuOTkuMjEzLjEzNS4yMDcuMTEzLjQzNC4yNTUuNjU1em0xNS4xODUgOC4xODNjLS40MzMuNTE4LS44Ni45NjItMS40NDMgMS4zM2wuNzA3LS44OTJjLjI1LS4xMzYuNDk3LS4yNzguNzM1LS40Mzh6bS0xMC4zNSAxLjMyNmMtLjU2OC0uMzY1LS45NzQtLjgxLTEuNDQtMS4zMjUuMjM3LjE2LjQ4NC4zLjczNC40MzdsLjcwNC44ODh6bS4zNi4yMTJsLS45NjMtMS4yMTJjLjQ1NC0uNDk4IDEuMjc4LS42NjMgMS45NS0uNTQ2bC42ODMgMS4yNjYtLjAxMy0uMDAyYy0uNTgzLS4wOC0xLjI0LjA1Ni0xLjY1OC40OTR6bTEuMjA2LTEuNzA4Yy41NTIuMTYyIDEuMjQuNjc2LjkzIDEuMzU1LS4wODQtLjAzOC0uMTctLjA2Ny0uMjYtLjA5MmwtLjY3LTEuMjYyem00LjY5NyAxLjYzbC0uNDMyLjkzM2MtLjkxLjExNS0xLjg0LjExNS0yLjc1IDBsLS40MzItLjkzNGMxLjE4LjE1NSAyLjQzNC4xNTUgMy42MTQgMHptLjMyNC0uMzRjLS4wNTYuMDE4LS4xMTQuMDQtLjE3LjA2NS0uMjgtLjYxMy4yNy0xLjEzLjgyLTEuMzJsLS42NSAxLjI1NXptMS45NjUuNDE3Yy0uNDM1LS40NTctMS4xMi0uNTg2LTEuNzI0LS40OGwtLjAxOC4wMDMuNjUtMS4yNmMuNjktLjE1MiAxLjU3Ny4wMDIgMi4wNTUuNTI1bC0uOTYyIDEuMjEzek00LjgyNSAyMC45OWwtMS40MDgtMS42MThoLjAwNWMuMzctLjA3Ljc3NC0uMDU1IDEuMTMuMDY2LjM1Ny4xMi43NS4zOTcuNzQ1LjgxMy0uMDA2LjMwOC0uMjE0LjU2LS40Ny43NHptMTIuOTcgMGwxLjQwOC0xLjYxOGgtLjAwNWMtLjM3LS4wNy0uNzc0LS4wNTUtMS4xMy4wNjYtLjM1Ny4xMi0uNzUyLjM5Ny0uNzQ1LjgxMy4wMDYuMzA4LjIxNS41Ni40Ny43NHptLTEzLjIxLTMuNDM0Yy0uMzEuMDU4LS42MzYuMDYzLS45NDQuMDA0LS4yMTguNTM4LS4zIDEuMDg3LS4yNTIgMS42MjguODYtLjE2IDEuNzM0LjEyNyAyLjAxLjY5LjI4LjU3Ny0uMTU0IDEuMjQtLjk5IDEuNTM0LjEzMi4xNDguMjc2LjI5Mi40My40M2wzLjMtMS42MmMtLjI0NC0uMjUyLS40Mi0uNTM2LS41MS0uODQtLjAzNS0uMDUtLjA3LS4xMDUtLjEwNC0uMTU4LS4yNDYuMTk0LS41OC4yMy0uOS4xOTctMS4wNjItLjExLTEuNTYtLjgyLTEuOTctMS43MTItLjAyMi0uMDQ1LS4wNDUtLjA5Ni0uMDctLjE1MnptMTMuMzEgNC4xODRjLjExMi0uMTA3LjIxOC0uMjE3LjMxNy0uMzI4LS44MzUtLjI5NS0xLjI3LS45NTctLjk4OC0xLjUzMy4yNzUtLjU2NSAxLjE0Ny0uODUgMi4wMS0uNjkyLjAwOC0uMDk0LjAxMi0uMTkuMDEyLS4yODQtLjY2LS4yNjUtMS4yMjctLjYyLTEuNTQ2LS45OS0uMTc1LS4yMDQtLjMyNC0uNDIzLS40NS0uNjU0LS4wODYtLjA1My0uMTY1LS4xMS0uMjM2LS4xNzUtLjQ4LjU3OC0xLjAwMyAxLjA2OC0xLjU2IDEuNDdsLS4wMS4wMmMtLjEyOC4yNTUtLjI3NC41MTItLjQ0Ljc1OC0uMDczLjI4My0uMjIuNTUtLjQzLjc5bDMuMzIgMS42MTd6bS02LjU4NSAyLjE2M2MuNi4wMSAxLjItLjAyNCAxLjc5Ny0uMTAzLS4zMDUtLjY0OC4xMi0xLjM0My45OTgtMS42MS44NjctLjI2MyAxLjg5My0uMDIyIDIuNDA0LjU0Mi40Ni0uMjUuODY2LS41MzMgMS4yMTUtLjgzOGwtMy4zMDUtMS42MDhjLS42NzMuNjUyLTEuODE1IDEuMDgtMy4xMSAxLjA4LTEuMjMzIDAtMi4zMjYtLjM4Ny0zLjAxLS45ODdsLTMuMjg3IDEuNjE0Yy4zMjIuMjY3LjY4OC41MTQgMS4xLjczOC41MS0uNTY0IDEuNTM2LS44MDYgMi40MDMtLjU0Mi44OC4yNjcgMS4zMDMuOTYyLjk5OCAxLjYxLjU5NC4wOCAxLjE5Ny4xMTMgMS43OTYuMTAzem05LjA0Ni0xMC45NzJsLjQ1My44ODZjLS4wMy4wMS0uMDU4LjAyNC0uMDg3LjAzNy0uMzA1LjE0LS41NDguMzYtLjczMy42MjVsLS41MDgtLjk5MmMtLjY0Mi4zMTYtMS4zNjQuNDk0LTIuMTI4LjQ5NC0yLjY2NCAwLTQuODI1LTIuMTYtNC44MjUtNC44MjVzMi4xNi00LjgyNiA0LjgyNC00LjgyNmMyLjY2NSAwIDQuODI2IDIuMTYgNC44MjYgNC44MjUgMCAxLjUzLS43MTMgMi44OTItMS44MjQgMy43NzZ6TTE3LjM1NCA1LjRjMi4wNzMgMCAzLjc1MyAxLjY4MiAzLjc1MyAzLjc1NHMtMS42OCAzLjc1My0zLjc1MyAzLjc1M2MtMi4wNzIgMC0zLjc1My0xLjY4LTMuNzUzLTMuNzUzIDAtMi4wNzMgMS42ODItMy43NTMgMy43NTQtMy43NTN6TTExLjMuNTY2YzEuOTggMCAzLjgwNi42NDcgNS4yODQgMS43NGwxLjQxLS4xMjhjLjYyNi0uMDg2IDEuMjU1LS4xODYgMS44ODYtLjIzIDEuODk4LS4xMzQgMS4zNDYuNTMzLjcxMyAyLjMyNmwtLjI0LjYyM2MtLjM1LS4yNDctLjczLS40NTItMS4xMzYtLjYwOC0uMTEtLjE2OC0uMjI1LS4zMzItLjM0NC0uNDkyLjA0LS4wNS4wODQtLjEwMi4xMjgtLjE1My41NzctLjY2IDEuMjYtMS4xMTYgMS45MjQtMS4zMzgtMS4xOTgtLjA5OC0yLjAzNS43ODMtMi42MzggMS42NTJsLjA2NC4wODJjLS4zMjItLjA2NC0uNjU1LS4wOTYtLjk5Ni0uMDk2LTIuODc2IDAtNS4yMDggMi4zMzItNS4yMDggNS4yMDhzMi4zMzIgNS4yMDggNS4yMDggNS4yMDhjLjM0IDAgLjY4LS4wMzMgMS4wMTItLjEtMS42MjQgMS42ODMtNC4xODQgMi41MTgtNy4wNjUgMi41MTgtNC45MDcgMC04Ljg4Ni0yLjQyLTguODg2LTcuMzMgMC0yLjA4Ny43Mi00LjAwNyAxLjkyNy01LjUyNC0uNTY3LS44NzMtMS40OC0xLjgwMy0yLjY2NC0xLjYyLjY2NS4yMjIgMS4zNDguNjc4IDEuOTIzIDEuMzM4LjA0My4wNS4wODUuMTAyLjEyNy4xNTMtLjQ1Ny42MTMtLjg0IDEuMjgtMS4xNCAxLjk5MmwtLjU4LTEuNTEzQzEuMzggMi40OTcuODMyIDEuODI2IDIuNjcgMS45NDRjLjU2OC4wMzYgMS4xMzYuMTE1IDEuNzAyLjE5Ny41NTIuMDggMS4wOTMuMTI1IDEuNjUuMTYzQzcuNDk2IDEuMjEgOS4zMi41NjUgMTEuMy41NjV6bTYuMDU0IDUuMjE4Yy0xLjg2IDAtMy4zNyAxLjUxLTMuMzcgMy4zN3MxLjUxIDMuMzcgMy4zNyAzLjM3IDMuMzctMS41MSAzLjM3LTMuMzctMS41MS0zLjM3LTMuMzctMy4zN3ptMS43NjIgOC40OWMuMDctLjA4Ni4xNC0uMTcyLjIwNi0uMjZsLjQyMi44MjRjLS4wNzYuMDQ3LS4xNTUuMDc1LS4yMjQuMDYtLjIwNi0uMDQtLjM0Ni0uNDEtLjQwNC0uNjI0eiIvPjxwYXRoIGQ9Ik0yNi44MDIgMTYuODk1Yy4xOTQuMTEuNDEzLjIyLjY1Ni4zMjMuMjQzLjEwNC41MDQuMTkuNzgyLjI2cy41NjMuMTA0Ljg1NS4xMDRjLjE4IDAgLjM2OC0uMDE0LjU2My0uMDQyLjE5NS0uMDI4LjM2NS0uMDgzLjUxLS4xNjcuMTQ3LS4wODMuMjctLjE5NC4zNjYtLjMzMy4wOTctLjE0LjE0Ni0uMzIuMTQ2LS41NDIgMC0uNDAzLS4xNTYtLjY5LS40Ny0uODY1LS4zMTItLjE3NC0uNzgtLjMyMy0xLjQwNi0uNDQ4LS40MDMtLjA4My0uNzkyLS4xOTQtMS4xNjctLjMzMy0uMzc1LS4xNC0uNzEtLjMyMy0xLS41NTMtLjI5My0uMjMtLjUyNi0uNTE4LS43LS44NjYtLjE3My0uMzQ3LS4yNi0uNzctLjI2LTEuMjdzLjExLS45NC4zMzMtMS4zMTRjLjIyMi0uMzc1LjUxOC0uNjk1Ljg4Ni0uOTYuMzY4LS4yNjMuNzk1LS40NiAxLjI4Mi0uNTkzLjQ4Ny0uMTMyLjk5NC0uMTk4IDEuNTIyLS4xOTguNTU2IDAgMS4wNTMuMDQgMS40OS4xMjQuNDM4LjA4NC44MTcuMTk1IDEuMTM2LjMzNC42MS4yNS45My41NzcuOTYuOTggMCAuMjEtLjA2Ny40NTUtLjIuNzQtLjEzLjI4NS0uMjc0LjU1Mi0uNDI3LjgwMi0uMTQtLjExLS4zMS0uMjI2LS41MTItLjM0NC0uMi0uMTE4LS40MjctLjIzLS42NzctLjMzNC0uMjUtLjEwNC0uNTEtLjE5LS43OC0uMjYtLjI3Mi0uMDctLjU0Ny0uMTA1LS44MjUtLjEwNS0uMTUzIDAtLjMxMy4wMS0uNDguMDMtLjE2Ni4wMjItLjMxNS4wNjMtLjQ0Ny4xMjZzLS4yNDMuMTUzLS4zMzMuMjdjLS4wOS4xMi0uMTM1LjI3NS0uMTM1LjQ3IDAgLjQ3Mi41MDcuODIgMS41MiAxLjA0Mi40MTguMDgzLjgzLjE5IDEuMjQuMzIzLjQxLjEzMi43OC4zMTYgMS4xMDYuNTUyLjMyNy4yMzYuNTkuNTM1Ljc5Mi44OTYuMi4zNi4zMDIuODEzLjMwMiAxLjM1NSAwIC41NTctLjEwOCAxLjA1LS4zMjMgMS40OC0uMjE1LjQzMi0uNTEuNzkzLS44ODYgMS4wODUtLjM3NC4yOTItLjgxNS41MTQtMS4zMjMuNjY3LS41MDcuMTUzLTEuMDYuMjMtMS42NTcuMjMtLjYxIDAtMS4xMy0uMDQ2LTEuNTUzLS4xMzYtLjQyNC0uMDktLjc3NS0uMTk4LTEuMDUzLS4zMjMtLjE5NS0uMDgzLS40MDctLjIwNS0uNjM2LS4zNjUtLjIzLS4xNi0uMzQ0LS4zOC0uMzQ0LS42NTcgMC0uMjM1LjA3LS40ODIuMjA4LS43NC4xNC0uMjU2LjMtLjUyMy40OC0uOC4xMjYuMTEuMjguMjMuNDYuMzU1em04Ljg4LTExLjEzMmMuODEzIDAgMS40NzIuNjYgMS40NzIgMS40NzMgMCAuODE0LS42NiAxLjQ3My0xLjQ3MyAxLjQ3My0uODEzIDAtMS40NzItLjY2LTEuNDcyLTEuNDc0cy42Ni0xLjQ3MyAxLjQ3My0xLjQ3M3pNMzQuMzQ3IDkuMzljLjA0LS4wMTQuMTU2LS4wMy4zNDQtLjA1Mi4xODctLjAyLjM5Mi0uMDMuNjE1LS4wMy4yMjIgMCAuNDQ1LjAyLjY2Ny4wNi4yMjMuMDQzLjQyNC4xMjMuNjA1LjI0LjE4LjEyLjMyNi4yODYuNDM3LjUwMi4xMS4yMTUuMTY3LjQ5Ny4xNjcuODQ0djguNDJjLS4wNTYuMDMtLjE4LjA1LS4zNzUuMDY0LS4xOTUuMDE0LS40MDQuMDItLjYyNi4wMi0uMjc4IDAtLjUyOC0uMDIzLS43NS0uMDcyLS4yMjMtLjA1LS40MTUtLjE0LS41NzQtLjI3LS4xNi0uMTMzLS4yODUtLjMxLS4zNzYtLjUzMy0uMDktLjIyMi0uMTM1LS41MDctLjEzNS0uODU1VjkuMzloLS4wMDJ6bTQuMTY4LTMuMTA2Yy4wOTctLjAxNC4yMDItLjAyOC4zMTMtLjA0LjA5Ni0uMDE1LjItLjAyNS4zMS0uMDMzLjExMi0uMDA2LjIyNC0uMDEuMzM1LS4wMS4yMjIgMCAuNDQ1LjAyMi42NjcuMDYzLjIyMi4wNDIuNDI0LjEyNS42MDUuMjUuMTguMTI1LjMyNi4yOTUuNDM4LjUxLjExLjIxNi4xNjYuNDk4LjE2Ni44NDV2MS40NmgyLjkydjIuMTI1aC0yLjkydjQuNDZjMCAuOTc0LjM5NyAxLjQ2IDEuMTkgMS40Ni4xOTMgMCAuMzc4LS4wMy41NS0uMDk0LjE3NS0uMDYzLjMzLS4xMzMuNDctLjIxLjE0LS4wNzUuMjYtLjE1NS4zNjUtLjI0LjEwNC0uMDgyLjE3Ny0uMTQ1LjIyLS4xODYuMjA3LjMwNi4zNjcuNTcuNDguNzkyLjExLjIyMi4xNjUuNDMuMTY1LjYyNSAwIC4xODItLjA3My4zNi0uMjIuNTMyLS4xNDUuMTc0LS4zNS4zMzQtLjYxNC40OC0uMjY0LjE0Ni0uNTg0LjI2NC0uOTYuMzU0LS4zNzQuMDktLjc4NC4xMzUtMS4yMjguMTM1LS44NjIgMC0xLjUzMi0uMTY2LTIuMDEyLS41LS40OC0uMzMzLS44MTYtLjc3LTEuMDEtMS4zMTItLjA5OC0uMjc4LS4xNi0uNTctLjE4OC0uODc2LS4wMjgtLjMwNi0uMDQyLS42MS0uMDQyLS45MTd2LTkuNjd6bTkuNDIyIDguNTI2Yy4wNTYuNzY0LjI5MiAxLjQuNzEgMS45MDcuNDE2LjUwNyAxLjA3Ni43NiAxLjk4Ljc2LjM0NyAwIC42NTItLjAzNy45MTYtLjExNC4yNjQtLjA3Ni41LS4xNy43MS0uMjguMjA3LS4xMTIuMzg4LS4yMzQuNTQtLjM2Ni4xNTQtLjEzMi4yOTMtLjI1NC40MTgtLjM2NS4xNjcuMjA4LjM0LjQ3Ni41Mi44MDIuMTguMzI3LjI3Mi41OTQuMjcyLjgwMyAwIC4zMDYtLjE3NC41ODQtLjUyLjgzNC0uMjkzLjIyMy0uNzA2LjQxNS0xLjI0Mi41NzQtLjUzNS4xNi0xLjE2NC4yNC0xLjg4Ni4yNC0uNjUzIDAtMS4yOTYtLjA4My0xLjkyOC0uMjUtLjYzMi0uMTY3LTEuMTk1LS40NTgtMS42OS0uODc1LS40OTItLjQxOC0uODkyLS45NzctMS4xOTgtMS42OC0uMzA2LS43LS40Ni0xLjU4Ny0uNDYtMi42NTcgMC0uODc2LjEzNi0xLjYzLjQwNy0yLjI2Mi4yNy0uNjMuNjMzLTEuMTU2IDEuMDg0LTEuNTczLjQ1Mi0uNDE3Ljk2My0uNzIyIDEuNTMzLS45MTcuNTctLjE5NCAxLjE1NC0uMjkyIDEuNzUtLjI5Mi43OCAwIDEuNDQuMTIgMS45OC4zNjUuNTQzLjI0My45ODQuNTcgMS4zMjUuOTguMzQuNDEuNTg3Ljg4Ljc0IDEuNDA3LjE1My41MjguMjMgMS4wODQuMjMgMS42Njh2LjI5MmMwIC4xMS0uMDA0LjIzLS4wMS4zNTRsLS4wMjIuMzY1Yy0uMDA3LjExNy0uMDE3LjIxLS4wMy4yOGgtNi4xMjh6bTMuNjI3LTEuNTYzYzAtLjY2Ny0uMTMtMS4yMS0uMzg2LTEuNjI2LS4yNTgtLjQxNi0uNzItLjYyNC0xLjM4Ny0uNjI0LS41NyAwLTEuMDI1LjE5OC0xLjM2NS41OTQtLjM0LjM5Ni0uNTEuOTQ4LS41MSAxLjY1N2gzLjY0N3pNNTYuMTcyIDE2Ljg5NWMuMTk1LjExLjQxNC4yMi42NTcuMzIzLjI0Mi4xMDQuNTAzLjE5Ljc4LjI2LjI4LjA3LjU2NC4xMDQuODU2LjEwNC4xOCAwIC4zNjgtLjAxNC41NjMtLjA0Mi4xOTMtLjAyOC4zNjQtLjA4My41MS0uMTY3LjE0Ni0uMDgzLjI2OC0uMTk0LjM2NS0uMzMzLjA5Ny0uMTQuMTQ2LS4zMi4xNDYtLjU0MiAwLS40MDMtLjE1NS0uNjktLjQ2OC0uODY1LS4zMTItLjE3NC0uNzgyLS4zMjMtMS40MDctLjQ0OC0uNDAzLS4wODMtLjc5Mi0uMTk0LTEuMTY3LS4zMzMtLjM3NS0uMTQtLjcxLS4zMjMtMS0uNTUzLS4yOTItLjIzLS41MjUtLjUxOC0uNjk4LS44NjYtLjE3NC0uMzQ3LS4yNi0uNzctLjI2LTEuMjdzLjExLS45NC4zMzMtMS4zMTRjLjIyMi0uMzc1LjUxNy0uNjk1Ljg4Ni0uOTYuMzY3LS4yNjMuNzk1LS40NiAxLjI4LS41OTMuNDg3LS4xMzIuOTk1LS4xOTggMS41MjMtLjE5OC41NTYgMCAxLjA1Mi4wNCAxLjQ5LjEyNC40MzguMDg0LjgxNy4xOTUgMS4xMzYuMzM0LjYxLjI1LjkzLjU3Ny45NTguOTggMCAuMjEtLjA2Ny40NTUtLjE5OC43NC0uMTMyLjI4NS0uMjc0LjU1Mi0uNDI4LjgwMi0uMTM4LS4xMS0uMzEtLjIyNi0uNTEtLjM0NC0uMjAyLS4xMTgtLjQyOC0uMjMtLjY3OC0uMzM0LS4yNS0uMTA0LS41MS0uMTktLjc4Mi0uMjYtLjI3LS4wNy0uNTQ1LS4xMDUtLjgyMy0uMTA1LS4xNTQgMC0uMzE0LjAxLS40OC4wMy0uMTY4LjAyMi0uMzE3LjA2My0uNDUuMTI2LS4xMy4wNjMtLjI0Mi4xNTMtLjMzMy4yNy0uMDkuMTItLjEzNS4yNzUtLjEzNS40NyAwIC40NzIuNTA3LjgyIDEuNTIyIDEuMDQyLjQxNy4wODMuODMuMTkgMS4yNC4zMjMuNDEuMTMyLjc3OC4zMTYgMS4xMDUuNTUyLjMyNS4yMzYuNTkuNTM1Ljc5Ljg5Ni4yLjM2Mi4zLjgxNC4zIDEuMzU2IDAgLjU1Ni0uMTA4IDEuMDUtLjMyMyAxLjQ4LS4yMTUuNDMtLjUxLjc5Mi0uODg2IDEuMDg0LS4zNzQuMjkyLS44MTUuNTE0LTEuMzIzLjY2Ny0uNTA3LjE1My0xLjA2LjIzLTEuNjU3LjIzLS42MSAwLTEuMTMtLjA0Ni0xLjU1My0uMTM2LS40MjQtLjA5LS43NzUtLjE5OC0xLjA1My0uMzIzLS4xOTUtLjA4My0uNDA2LS4yMDUtLjYzNi0uMzY1LS4yMy0uMTYtLjM0NC0uMzgtLjM0NC0uNjU4IDAtLjIzNi4wNy0uNDgzLjIwOC0uNzQuMTQtLjI1Ny4zLS41MjQuNDgtLjgwMi4xMjcuMTEuMjguMjMuNDYuMzU1ek02My43NSA5LjM5Yy4wNy0uMDE0LjE1My0uMDI4LjI1LS4wNDIuMDgzLS4wMTQuMTgtLjAyNC4yOTItLjAzLjExLS4wMDguMjQzLS4wMTIuMzk2LS4wMTIuNDU4IDAgLjg0OC4wNzcgMS4xNjcuMjMuMzIuMTUyLjUyLjQxLjYwNS43Ny4yMjItLjI2NC41Ny0uNTMgMS4wNDItLjgwMi40NzMtLjI3IDEuMDctLjQwNiAxLjc5My0uNDA2LjUxNCAwIDEuMDA0LjA4NyAxLjQ3LjI2LjQ2NS4xNzQuODc4LjQ1NiAxLjI0Ljg0NS4zNi4zOS42NS45MDMuODY1IDEuNTQzLjIxNS42NC4zMjMgMS40MjQuMzIzIDIuMzU2IDAgMS4wODQtLjEyNSAxLjk3Ny0uMzc1IDIuNjc4LS4yNS43MDItLjU3MyAxLjI1OC0uOTcgMS42NjgtLjM5Ni40MS0uODM3LjY5OC0xLjMyNC44NjUtLjQ4Ni4xNjctLjk3My4yNS0xLjQ2LjI1LS40MDIgMC0uNzUzLS4wNDUtMS4wNS0uMTM2LS4zLS4wOS0uNTUzLS4xOS0uNzYyLS4zMDItLjIxLS4xMS0uMzY4LS4yMjItLjQ4LS4zMzRzLS4xOC0uMTg3LS4yMDgtLjIyOHYzLjE1M0g2My43NVY5LjM5em0yLjgzNSA3LjMxN2MuMTEuMTEuMzEuMjQzLjU5NC4zOTYuMjg0LjE1My42MTQuMjMuOTkuMjMuNzA4IDAgMS4yMy0uMjggMS41NjMtLjgzNS4zMzMtLjU1Ni41LTEuMzM0LjUtMi4zMzUgMC0uNDE3LS4wMzUtLjgwNi0uMTA1LTEuMTY3LS4wNy0uMzYtLjE4NC0uNjc0LS4zNDQtLjkzOC0uMTYtLjI2NC0uMzc1LS40Ny0uNjQ2LS42MTUtLjI3LS4xNDYtLjYtLjIyLS45OS0uMjItLjU4NCAwLS45OS4xMTItMS4yMi4zMzUtLjIzLjIyMi0uMzQ0LjQ2NS0uMzQ0LjczdjQuNDJ6TTc3LjA1IDE0LjgxYy4wNTQuNzY0LjI5IDEuNC43MDcgMS45MDcuNDE3LjUwNyAxLjA3OC43NiAxLjk4Ljc2LjM1IDAgLjY1NC0uMDM3LjkyLS4xMTQuMjYzLS4wNzcuNS0uMTcuNzA3LS4yOC4yMS0uMTEyLjM5LS4yMzQuNTQyLS4zNjYuMTUzLS4xMzIuMjkyLS4yNTQuNDE3LS4zNjUuMTY2LjIxLjM0LjQ3Ni41Mi44MDMuMTguMzI3LjI3Mi41OTQuMjcyLjgwMyAwIC4zMDYtLjE3NC41ODMtLjUyLjgzNC0uMjkzLjIyMi0uNzA3LjQxNC0xLjI0Mi41NzMtLjUzNC4xNi0xLjE2NC4yNC0xLjg4Ni4yNC0uNjUzIDAtMS4yOTUtLjA4NC0xLjkyOC0uMjUtLjYzNC0uMTY3LTEuMTk2LS40Ni0xLjY5LS44NzYtLjQ5My0uNDE4LS44OTItLjk3Ny0xLjE5OC0xLjY4LS4zMDYtLjctLjQ2LTEuNTg3LS40Ni0yLjY1NyAwLS44NzYuMTM3LTEuNjMuNDA4LTIuMjYyLjI3LS42My42MzItMS4xNTYgMS4wODMtMS41NzMuNDUyLS40MTcuOTYyLS43MjMgMS41MzItLjkxNy41Ny0uMTk1IDEuMTUzLS4yOTIgMS43NS0uMjkyLjc4IDAgMS40NC4xMiAxLjk4Mi4zNjUuNTQyLjI0My45ODMuNTcgMS4zMjQuOTguMzQuNDEuNTg4Ljg4Ljc0IDEuNDA3cy4yMyAxLjA4NC4yMyAxLjY2OHYuMjkyYzAgLjExLS4wMDMuMjMtLjAxLjM1NGwtLjAyLjM2NWMtLjAwOC4xMTctLjAxOC4yMS0uMDMyLjI4aC02LjEzem0zLjYyNS0xLjU2M2MwLS42NjctLjEyOC0xLjIxLS4zODYtMS42MjYtLjI1OC0uNDE2LS43Mi0uNjI0LTEuMzg3LS42MjQtLjU3IDAtMS4wMjUuMTk4LTEuMzY1LjU5NC0uMzQuMzk2LS41MS45NDgtLjUxIDEuNjU3aDMuNjQ3em02LjI1NCAxLjU2M2MuMDU0Ljc2NC4yOSAxLjQuNzA4IDEuOTA3LjQxNy41MDcgMS4wNzcuNzYgMS45OC43Ni4zNDggMCAuNjU0LS4wMzcuOTE4LS4xMTQuMjY0LS4wNzcuNS0uMTcuNzEtLjI4LjIwNy0uMTEyLjM4OC0uMjM0LjU0LS4zNjYuMTU0LS4xMzIuMjkzLS4yNTQuNDE4LS4zNjUuMTY3LjIxLjM0LjQ3Ni41Mi44MDMuMTgyLjMyNy4yNzIuNTk0LjI3Mi44MDMgMCAuMzA2LS4xNzQuNTgzLS41Mi44MzQtLjI5My4yMjItLjcwNi40MTQtMS4yNC41NzMtLjUzNi4xNi0xLjE2NS4yNC0xLjg4Ny4yNC0uNjU1IDAtMS4yOTctLjA4NC0xLjkzLS4yNS0uNjMyLS4xNjctMS4xOTUtLjQ2LTEuNjg4LS44NzYtLjQ5My0uNDE4LS44OTItLjk3Ny0xLjItMS42OC0uMzA0LS43LS40NTgtMS41ODctLjQ1OC0yLjY1NyAwLS44NzYuMTM2LTEuNjMuNDA3LTIuMjYyLjI3Mi0uNjMuNjM0LTEuMTU2IDEuMDg1LTEuNTczLjQ1LS40MTcuOTYyLS43MjMgMS41MzItLjkxNy41Ny0uMTk1IDEuMTU0LS4yOTIgMS43NTItLjI5Mi43NzcgMCAxLjQzNy4xMiAxLjk4LjM2NS41NC4yNDMuOTgyLjU3IDEuMzIzLjk4LjM0LjQxLjU4Ny44OC43NCAxLjQwNy4xNTQuNTI4LjIzIDEuMDg0LjIzIDEuNjY4di4yOTJjMCAuMTEtLjAwMy4yMy0uMDEuMzU0bC0uMDIyLjM2NWMtLjAwNS4xMTctLjAxNi4yMS0uMDMuMjhoLTYuMTN6bTMuNjI2LTEuNTYzYzAtLjY2Ny0uMTMtMS4yMS0uMzg2LTEuNjI2LS4yNTctLjQxNi0uNzItLjYyNC0xLjM4Ni0uNjI0LS41NyAwLTEuMDI1LjE5OC0xLjM2Ni41OTQtLjM0LjM5Ni0uNTEuOTQ4LS41MSAxLjY1N2gzLjY0OHptMTAuMTcyLTEuMzc2Yy0uMTEtLjExLS4zMDItLjI0Mi0uNTczLS4zOTUtLjI3LS4xNTMtLjU4Ny0uMjMtLjk0OC0uMjMtLjcyMyAwLTEuMjU3LjI2NS0xLjYwNS43OTMtLjM0OC41MjgtLjUyIDEuMjg1LS41MiAyLjI3MiAwIC40ODYuMDM0LjkyOC4xMDMgMS4zMjQuMDcuMzk2LjE4OC43MzMuMzU1IDEuMDEuMTY2LjI4LjM5LjQ5NC42NjcuNjQ3LjI3OC4xNTQuNjMzLjIzIDEuMDYzLjIzLjQwNCAwIC43NDctLjA4MyAxLjAzMi0uMjUuMjg1LS4xNjcuNDI3LS40MDMuNDI3LS43MXYtNC42OWgtLjAwMnptLjk4IDcuMzhjLS4yMzYgMC0uNDI0LS4wOC0uNTYzLS4yNC0uMTQtLjE2LS4yMS0uMzY1LS4yMS0uNjE1LS4xOTQuMjM2LS41MjQuNDgtLjk5LjczLS40NjUuMjUtMS4wNi4zNzUtMS43OC4zNzUtLjUxNSAwLTEuMDEyLS4wODMtMS40OTItLjI1LS40OC0uMTY3LS45MDYtLjQ0NS0xLjI4LS44MzQtLjM3Ni0uMzktLjY3NS0uOTA3LS44OTctMS41NTMtLjIyMy0uNjQ2LS4zMzQtMS40NS0uMzM0LTIuNDA4IDAtLjk2LjExNS0xLjc4LjM0NC0yLjQ2LjIzLS42OC41MzUtMS4yMzMuOTE3LTEuNjU3LjM4Mi0uNDI0LjgyLS43MzcgMS4zMTQtLjkzOC40OTMtLjIwMiAxLjAxLS4zMDIgMS41NTMtLjMwMi42MjUgMCAxLjE0LjEwOCAxLjU0Mi4zMjMuNDA0LjIxNi43MDIuNDI4Ljg5Ni42Mzd2LTMuODRjLjA5Ny0uMDI4LjI0NC0uMDUuNDM4LS4wNjMuMTk1LS4wMTQuMzctLjAyLjUyLS4wMi4yMjMgMCAuNDUuMDIuNjc4LjA2Mi4yMy4wNDIuNDM0LjEyNS42MTUuMjUuMTguMTI1LjMyMi4yOTUuNDI3LjUxLjEwNC4yMTYuMTU2LjQ5OC4xNTYuODQ1djExLjQ1aC0xLjg1NXpNMTA1LjI1MyAxOS4xNzNjLS4yNzQtLjMtLjQxLS42Ny0uNDEtMS4xMXMuMTQzLS43OTguNDMtMS4wOGMuMjg3LS4yOC42NS0uNDIgMS4wOS0uNDIuNDM4IDAgLjguMTQgMS4wODguNDIuMjkuMjgyLjQzMy42NC40MzMgMS4wOHMtLjEzNy44MDUtLjQxIDEuMWMtLjI3NS4yOTQtLjY0NS40NC0xLjExLjQ0LS40NTMgMC0uODIzLS4xNDMtMS4xMS0uNDN6bTMuNzQtOS41OTdjLjA0LS4wMTQuMTUzLS4wMy4zMzgtLjA1Mi4xODYtLjAyLjM4OC0uMDMuNjA3LS4wMy4yMiAwIC40NC4wMi42NTguMDYuMjIuMDQyLjQxOC4xMi41OTYuMjM3LjE4LjExNy4zMjMuMjgyLjQzMy40OTQuMTEuMjEyLjE2NC40OS4xNjQuODMydjguMzAyYy0uMDU1LjAyNy0uMTc4LjA0OC0uMzcuMDYtLjE5Mi4wMTUtLjM5Ny4wMi0uNjE2LjAyLS4yNzMgMC0uNTItLjAyMy0uNzQtLjA3LS4yMTgtLjA1LS40MDctLjEzOC0uNTY0LS4yNjgtLjE1OC0uMTMtLjI4LS4zMDUtLjM3LS41MjQtLjA4OC0uMjItLjEzMy0uNS0uMTMzLS44NDJWOS41NzZ6bS0uMDA0LTIuMjRjMC0uNDM3LjE0My0uNzk3LjQzLTEuMDc4LjI4OC0uMjguNjQ0LS40MiAxLjA3LS40Mi40MSAwIC43NjMuMTQgMS4wNTcuNDIuMjk1LjI4LjQ0My42NC40NDMgMS4wOCAwIC40MzgtLjE0OC43OTQtLjQ0MyAxLjA2OC0uMjk0LjI3NC0uNjQ3LjQxLTEuMDU4LjQxLS40MjYgMC0uNzgtLjEzNi0xLjA3LS40MS0uMjg3LS4yNzQtLjQzLS42My0uNDMtMS4wN3ptNS4xIDEwLjcyN2MtLjM4NC0uNDgtLjY2NS0xLjAzLS44NDMtMS42NTQtLjE4LS42MjQtLjI2Ny0xLjI4LS4yNjctMS45NjMgMC0uNy4xMDItMS4zNi4zMDgtMS45ODMuMjA1LS42MjMuNTEtMS4xNzIuOTE0LTEuNjQ0LjQwNC0uNDczLjkxNC0uODQ2IDEuNTMyLTEuMTIuNjE2LS4yNzQgMS4zMzYtLjQxIDIuMTU4LS40MS44NjMgMCAxLjYuMTM2IDIuMjEuNDEuNjEuMjc0IDEuMTAyLjY0NCAxLjQ4IDEuMTEuMzc2LjQ2NS42NSAxLjAwNi44MiAxLjYyMi4xNzIuNjE2LjI1OCAxLjI2Ny4yNTggMS45NTJzLS4wODYgMS4zNDMtLjI1NyAxLjk3M2MtLjE3LjYzLS40NTIgMS4xODUtLjg0MiAxLjY2NC0uMzkuNDgtLjg5My44NjQtMS41MSAxLjE1Mi0uNjE1LjI4OC0xLjM2Mi40My0yLjI0LjQzLS44NzYgMC0xLjYyLS4xNC0yLjIzLS40Mi0uNjEtLjI4LTEuMTA3LS42NTMtMS40OS0xLjEyem0yLjcxMi0uODIyYy4yNzQuMTguNjEuMjY4IDEuMDA3LjI2OC40MSAwIC43NS0uMDkgMS4wMTYtLjI2Ny4yNjctLjE3Ny40NzYtLjQxNC42MjctLjcwOC4xNS0uMjk1LjI1My0uNjI3LjMxLS45OTcuMDUzLS4zNy4wOC0uNzQ3LjA4LTEuMTMgMC0uMzctLjAyNy0uNzM2LS4wOC0xLjEtLjA1Ni0uMzYyLS4xNi0uNjgtLjMxLS45NTUtLjE1LS4yNzQtLjM1Ni0uNDk3LS42MTYtLjY2OC0uMjYtLjE3LS41OS0uMjU3LS45ODctLjI1N3MtLjczLjA5LS45OTYuMjY3Yy0uMjY3LjE3OC0uNDguNDA4LS42MzcuNjg4LS4xNTguMjgtLjI3LjYtLjM0Ljk1Ni0uMDY4LjM1Ni0uMTAyLjcyLS4xMDIgMS4wOSAwIC4zNy4wMy43NC4wOTMgMS4xMDguMDYyLjM3LjE2OC43MDIuMzE4Ljk5Ny4xNS4yOTYuMzU1LjUzMy42MTYuNzF6Ii8+PC9nPjwvc3ZnPg==",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 7310
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 2.16299999738112,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.6020000146236302,
+          "wait": 229.84699998050925,
+          "receive": 3.0560000159312324,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.322Z",
+        "time": 235.57499999878928,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/socialmedia/facebook-round.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/socialmedia/facebook-round.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-length",
+              "value": "592"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "5.079ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"250-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/svg+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 592,
+            "mimeType": "image/svg+xml",
+            "text": "PHN2ZyBjbGFzcz0iY3VzdG9tLWljb24iIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHN0eWxlPSJoZWlnaHQ6MTAwcHg7d2lkdGg6MTAwcHgiIHdpZHRoPSIxMDBweCIgaGVpZ2h0PSIxMDBweCI+PGNpcmNsZSBjbGFzcz0ib3V0ZXItc2hhcGUiIGN4PSI1MCIgY3k9IjUwIiByPSI0OCIgZmlsbD0iIzNCNTk5OCIvPjxwYXRoIGNsYXNzPSJpbm5lci1zaGFwZSIgZD0iTTY2LjMzNCAyNS41SDMzLjY2OGMtNC40OTIgMC04LjE2OCAzLjY3Ni04LjE2OCA4LjE2OHYzMi42NjRjMCA0LjQ5NiAzLjY3NSA4LjE2OCA4LjE2NyA4LjE2OGgzMi42NjZjNC40OTMgMCA4LjE2Ny0zLjY3MiA4LjE2Ny04LjE2N1YzMy42N2MwLTQuNDkzLTMuNjc0LTguMTctOC4xNjYtOC4xN3pNNjcuMTYgNTBoLTcuOTczdjIxLjQzOEg1MFY1MGgtNC40Mjh2LTcuMDE0SDUwdi00LjU1NGMwLTYuMTkgMi42Ny05Ljg3IDkuOTQ3LTkuODdoOC4zODZ2Ny41ODhoLTYuODVjLTIuMDMzLS4wMDQtMi4yODUgMS4wNi0yLjI4NSAzLjA0bC0uMDEgMy43OTZoOS4xODdMNjcuMTYgNTB6IiBmaWxsPSIjZjdmN2Y3Ii8+PC9zdmc+Cg==",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 1192
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 1.95400000666268,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.56499999482185,
+          "wait": 230.16500001540447,
+          "receive": 2.890999981900279,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.322Z",
+        "time": 235.50699997576885,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/socialmedia/twitter-round.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/socialmedia/twitter-round.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-length",
+              "value": "923"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "4.334ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"39b-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/svg+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 923,
+            "mimeType": "image/svg+xml",
+            "text": "PHN2ZyBjbGFzcz0iY3VzdG9tLWljb24iIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHN0eWxlPSJoZWlnaHQ6MTAwcHg7d2lkdGg6MTAwcHgiIHdpZHRoPSIxMDBweCIgaGVpZ2h0PSIxMDBweCI+PGNpcmNsZSBjbGFzcz0ib3V0ZXItc2hhcGUiIGN4PSI1MCIgY3k9IjUwIiByPSI0OCIgZmlsbD0iIzAwQUNFRCIvPjxwYXRoIGNsYXNzPSJpbm5lci1zaGFwZSIgZD0iTTc0LjUgMzQuNzE0Yy0xLjgwMi44MDQtMy43NCAxLjM0Ny01Ljc3MyAxLjU5MiAyLjA3NS0xLjI1MiAzLjY3LTMuMjMzIDQuNDItNS41OTUtMS45NDIgMS4xNi00LjA5MyAyLTYuMzgzIDIuNDU1LTEuODM0LTEuOTY1LTQuNDQ3LTMuMTkzLTcuMzM4LTMuMTkzLTUuNTUyIDAtMTAuMDU0IDQuNTI3LTEwLjA1NCAxMC4xMSAwIC43OTQuMDkgMS41NjUuMjYgMi4zMDYtOC4zNTUtLjQyMy0xNS43NjItNC40NDgtMjAuNzItMTAuNTY2LS44NjYgMS40OTQtMS4zNjIgMy4yMy0xLjM2MiA1LjA4NCAwIDMuNTEgMS43NzUgNi42MDQgNC40NzMgOC40MTctMS42NDgtLjA1Mi0zLjItLjUwNy00LjU1My0xLjI2NHYuMTI2YzAgNC45IDMuNDY0IDguOTg2IDguMDYzIDkuOTE2LS44NDQuMjMtMS43My4zNTUtMi42NDguMzU1LS42NDggMC0xLjI3OC0uMDY0LTEuODkyLS4xODIgMS4yOCA0LjAxNyA0Ljk5MiA2Ljk0IDkuMzkgNy4wMjMtMy40NCAyLjcxMi03Ljc3NCA0LjMyOC0xMi40ODQgNC4zMjgtLjgxMyAwLTEuNjEzLS4wNDgtMi40LS4xNCA0LjQ1IDIuODY4IDkuNzM0IDQuNTQzIDE1LjQxIDQuNTQzIDE4LjQ5MiAwIDI4LjYwNC0xNS40MSAyOC42MDQtMjguNzczIDAtLjQzOC0uMDEtLjg3NC0uMDMtMS4zMDggMS45NjQtMS40MjggMy42Ny0zLjIxIDUuMDE3LTUuMjM2eiIgZmlsbD0iI2Y3ZjdmNyIvPjwvc3ZnPgo=",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 1523
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 1.74999999580905,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.5280000041238899,
+          "wait": 230.42799998074807,
+          "receive": 2.8009999950878353,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.322Z",
+        "time": 235.51399999996647,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/socialmedia/github-round.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/socialmedia/github-round.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "3.617ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"6b3-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/svg+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 1715,
+            "mimeType": "image/svg+xml",
+            "text": "PHN2ZyBjbGFzcz0iY3VzdG9tLWljb24iIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHN0eWxlPSJoZWlnaHQ6MTAwcHg7d2lkdGg6MTAwcHgiIHdpZHRoPSIxMDBweCIgaGVpZ2h0PSIxMDBweCI+PGNpcmNsZSBjbGFzcz0ib3V0ZXItc2hhcGUiIGN4PSI1MCIgY3k9IjUwIiByPSI0OCIgZmlsbD0iIzNFM0UzRSIvPjxwYXRoIGNsYXNzPSJpbm5lci1zaGFwZSIgZD0iTTUwIDI1LjVjLTEzLjUzIDAtMjQuNSAxMC45Ny0yNC41IDI0LjVTMzYuNDcgNzQuNSA1MCA3NC41IDc0LjUgNjMuNTMgNzQuNSA1MCA2My41MyAyNS41IDUwIDI1LjV6bTE0LjU1IDM5LjA1Yy0xLjg5MiAxLjg5LTQuMDkzIDMuMzc0LTYuNTQyIDQuNDEtLjYyMy4yNjQtMS4yNTUuNDk2LTEuODk1LjY5NVY2NS45OGMwLTEuOTMtLjY2Mi0zLjM1LTEuOTg2LTQuMjU4LjgzLS4wOCAxLjU5LS4xOSAyLjI4NS0uMzM1LjY5NC0uMTQ0IDEuNDI3LS4zNTIgMi4yLS42MjMuNzc0LS4yNzIgMS40NjgtLjU5NSAyLjA4Mi0uOTcuNjE0LS4zNzQgMS4yMDUtLjg2IDEuNzctMS40NnMxLjA0Mi0xLjI3NSAxLjQyNC0yLjAzMy42ODYtMS42NjYuOTEtMi43MjdjLjIyMi0xLjA2LjMzNC0yLjIzLjMzNC0zLjUwNSAwLTIuNDczLS44MDUtNC41NzctMi40MTYtNi4zMTYuNzMzLTEuOTE0LjY1NC0zLjk5Ni0uMjQtNi4yNDVsLS41OTgtLjA3Yy0uNDE0LS4wNDgtMS4xNi4xMjctMi4yMzcuNTI2LTEuMDc1LjQtMi4yODQgMS4wNTItMy42MjMgMS45NjItMS45LS41MjYtMy44NjgtLjc5LTUuOTEtLjc5LTIuMDU4IDAtNC4wMi4yNjQtNS44ODYuNzktLjg0NC0uNTc0LTEuNjQ2LTEuMDQ4LTIuNDA0LTEuNDIzLS43NTctLjM3NS0xLjM2My0uNjMtMS44MTgtLjc2Ni0uNDU1LS4xMzctLjg3Ny0uMjItMS4yNjgtLjI1My0uMzktLjAzMi0uNjQyLS4wNC0uNzU0LS4wMjQtLjExLjAxNi0uMTkuMDMyLS4yNC4wNDgtLjg5MiAyLjI2Ni0uOTcyIDQuMzQ4LS4yMzggNi4yNDYtMS42MSAxLjczOC0yLjQxNiAzLjg0NC0yLjQxNiA2LjMxNiAwIDEuMjc2LjExIDIuNDQ1LjMzNSAzLjUwNS4yMjMgMS4wNi41MjYgMS45Ny45MSAyLjcyOC4zOC43NTcuODU2IDEuNDM1IDEuNDIyIDIuMDMzczEuMTU2IDEuMDg1IDEuNzcgMS40NmMuNjE0LjM3NSAxLjMwOC42OTggMi4wOC45Ny43NzUuMjcgMS41MDguNDc3IDIuMjAyLjYyLjY5NC4xNDUgMS40NTYuMjU3IDIuMjg1LjMzNi0xLjMwOC44OTQtMS45NjIgMi4zMTMtMS45NjIgNC4yNnYzLjc0MmMtLjcyMi0uMjE1LTEuNDM0LS40Ny0yLjEzNC0uNzY1LTIuNDQ4LTEuMDM1LTQuNjUtMi41Mi02LjU0LTQuNDEtMS44OS0xLjg5LTMuMzc1LTQuMDkyLTQuNDEyLTYuNTQyLTEuMDctMi41MzQtMS42MTUtNS4yMjgtMS42MTUtOC4wMDhzLjU0NC01LjQ3NCAxLjYxNi04LjAwOGMxLjAzNS0yLjQ1IDIuNTItNC42NSA0LjQxLTYuNTRzNC4wOTItMy4zNzYgNi41NDItNC40MTNjMi41MzQtMS4wNzMgNS4yMjgtMS42MTYgOC4wMDgtMS42MTZzNS40NzQuNTQzIDguMDA4IDEuNjE1YzIuNDUgMS4wMzYgNC42NSAyLjUyIDYuNTQgNC40MSAxLjg5MiAxLjg5MiAzLjM3NiA0LjA5MyA0LjQxMyA2LjU0MiAxLjA3MiAyLjUzNSAxLjYxNiA1LjIzIDEuNjE2IDguMDA4cy0uNTQ0IDUuNDc0LTEuNjE2IDguMDA4Yy0xLjAzNiAyLjQ1LTIuNTIgNC42NS00LjQxIDYuNTQyeiIgZmlsbD0iI2Y3ZjdmNyIvPjwvc3ZnPgo=",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 1491
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 1.51600001845509,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.5149999924469699,
+          "wait": 230.87699999450695,
+          "receive": 2.6059999945574646,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.394Z",
+        "time": 6.03299998329021,
+        "request": {
+          "method": "GET",
+          "url": "https://www.google-analytics.com/collect?v=1&_v=j40&a=503183539&t=pageview&_s=1&dl=https%3A%2F%2Frun.sitespeed.io%2F&ul=en-us&de=UTF-8&dt=Analyze%20your%20page%20against%20web%20performance%20best%20practice%20rules%20and%20using%20metrics&sd=24-bit&sr=1440x900&vp=1130x229&je=0&fl=20.0%20r0&_utma=152498875.1418992272.1383681826.1452810533.1452841975.773&_utmz=152498875.1450310184.754.50.utmcsr%3Dcheckpagerank.net%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Findex.php&_utmht=1453185990390&_u=AACCAEABI~&jid=&cid=1418992272.1383681826&tid=UA-31246987-3&z=1014282684",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/collect?v=1&_v=j40&a=503183539&t=pageview&_s=1&dl=https%3A%2F%2Frun.sitespeed.io%2F&ul=en-us&de=UTF-8&dt=Analyze%20your%20page%20against%20web%20performance%20best%20practice%20rules%20and%20using%20metrics&sd=24-bit&sr=1440x900&vp=1130x229&je=0&fl=20.0%20r0&_utma=152498875.1418992272.1383681826.1452810533.1452841975.773&_utmz=152498875.1450310184.754.50.utmcsr%3Dcheckpagerank.net%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Findex.php&_utmht=1453185990390&_u=AACCAEABI~&jid=&cid=1418992272.1383681826&tid=UA-31246987-3&z=1014282684"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "www.google-analytics.com"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [
+            {
+              "name": "v",
+              "value": "1"
+            },
+            {
+              "name": "_v",
+              "value": "j40"
+            },
+            {
+              "name": "a",
+              "value": "503183539"
+            },
+            {
+              "name": "t",
+              "value": "pageview"
+            },
+            {
+              "name": "_s",
+              "value": "1"
+            },
+            {
+              "name": "dl",
+              "value": "https%3A%2F%2Frun.sitespeed.io%2F"
+            },
+            {
+              "name": "ul",
+              "value": "en-us"
+            },
+            {
+              "name": "de",
+              "value": "UTF-8"
+            },
+            {
+              "name": "dt",
+              "value": "Analyze%20your%20page%20against%20web%20performance%20best%20practice%20rules%20and%20using%20metrics"
+            },
+            {
+              "name": "sd",
+              "value": "24-bit"
+            },
+            {
+              "name": "sr",
+              "value": "1440x900"
+            },
+            {
+              "name": "vp",
+              "value": "1130x229"
+            },
+            {
+              "name": "je",
+              "value": "0"
+            },
+            {
+              "name": "fl",
+              "value": "20.0%20r0"
+            },
+            {
+              "name": "_utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773"
+            },
+            {
+              "name": "_utmz",
+              "value": "152498875.1450310184.754.50.utmcsr%3Dcheckpagerank.net%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Findex.php"
+            },
+            {
+              "name": "_utmht",
+              "value": "1453185990390"
+            },
+            {
+              "name": "_u",
+              "value": "AACCAEABI~"
+            },
+            {
+              "name": "jid",
+              "value": ""
+            },
+            {
+              "name": "cid",
+              "value": "1418992272.1383681826"
+            },
+            {
+              "name": "tid",
+              "value": "UA-31246987-3"
+            },
+            {
+              "name": "z",
+              "value": "1014282684"
+            }
+          ],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 15 Jan 2016 13:55:49 GMT"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "last-modified",
+              "value": "Sun, 17 May 1998 03:00:00 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Golfe2"
+            },
+            {
+              "name": "age",
+              "value": "319837"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "content-type",
+              "value": "image/gif"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store, must-revalidate"
+            },
+            {
+              "name": "content-length",
+              "value": "35"
+            },
+            {
+              "name": "expires",
+              "value": "Mon, 01 Jan 1990 00:00:00 GMT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 35,
+            "mimeType": "image/gif",
+            "text": "R0lGODlhAQABAID/AP///wAAACwAAAAAAQABAAACAkQBADs=",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 117
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.59699997655116,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.16600001254119,
+          "wait": 4.03300000471063,
+          "receive": 1.2369999894872308,
+          "ssl": -1
+        },
+        "connection": "1043854",
+        "pageref": "page_5"
+      }
+    ]
+  }
+}

--- a/test/har/files/mimeTypesIncorrect.har
+++ b/test/har/files/mimeTypesIncorrect.har
@@ -1,0 +1,2083 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-01-19T06:46:30.145Z",
+        "id": "page_5",
+        "title": "https://run.sitespeed.io/",
+        "pageTimings": {
+          "onContentLoad": 220.09099999559112,
+          "onLoad": 421.81800000253133
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-01-19T06:46:30.145Z",
+        "time": 117.03599998145364,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "upgrade-insecure-requests",
+              "value": "1"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "x-response-time",
+              "value": "19.948ms"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"2jB3aYr1qW9k73mquCnXUA==\""
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 12311,
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE html><html lang=en><head><meta charset=utf-8><meta name=viewport content=\"initial-scale=1\"><title>Analyze your page against web performance best practice rules and using metrics</title><link rel=apple-touch-icon-precomposed sizes=144x144 href=/img/ico/sitespeed.io-144.png><link rel=apple-touch-icon-precomposed sizes=114x114 href=/img/ico/sitespeed.io-114.png><link rel=apple-touch-icon-precomposed sizes=72x72 href=/img/ico/sitespeed.io-72.png><link rel=apple-touch-icon-precomposed href=/img/ico/sitespeed.io-57.png><link rel=\"shortcut icon\" href=/img/ico/sitespeed.io.ico><meta name=description content=\"How fast is your site? How good does it follow web performance best practice rules? Find out by using sitespeed.io.\"><meta name=keywords content=\"sitespeed.io, wpo, webperf, perfmatters, performance\"><style>*{-moz-box-sizing:border-box;box-sizing:border-box;line-height:1.5em}html{height:100%}div,p,a,li,td,span{-webkit-text-size-adjust:none;font-family:Verdana,sans-serif;-webkit-box-sizing:border-box}h1{font-weight:700;font-size:30px;margin:0}h2{font-weight:700;font-size:20px}body{margin:0;padding:0;height:100%;font-size:14px;padding-bottom:72px}a{color:#428bca;text-decoration:none}form a{color:#fff;text-decoration:underline}#container{min-height:100%;position:relative;background:#fff}.homelink{text-indent:-9999px;display:block}footer{background-color:#e1f6fd}#footer-wrapper{float:left}.footerlist{color:#00517c;overflow:hidden;margin:0}.footerlist li{float:left;list-style-type:none;padding:5px 10px}footer .homelink{background:transparent url(../img/logos/logoFooter.svg) 0 center / contain no-repeat}.footerlist li a{color:#00517c;padding:0;text-decoration:none;display:block}#footerlinks{float:left}#footershare{float:right}#footershare li{margin:10px 0}#footershare li a{display:block}#footershare .facebook a{background:transparent url(../img/socialmedia/facebook-round.svg) center center /contain no-repeat}#footershare .twitter a{background:transparent url(../img/socialmedia/twitter-round.svg) center center /contain no-repeat}#footershare .github a{background:transparent url(../img/socialmedia/github-round.svg) center center /contain no-repeat}.photo{border-radius:10px;margin-right:20px;margin-bottom:10px}.pull-left{float:left!important}body#start{border-top-width:18px}#start header{background-color:transparent;margin-top:0}#start #page:before{display:none}#start header:before{display:none}#start #content{background:transparent url(../img/logos/logoBig2.svg) 0 0 / 100% no-repeat}#start #container{background:#0095d2 url(../img/bg_cat.png) 75% 36px no-repeat}#analyze-form{color:#fff;width:100%;overflow:hidden}#analyze-form label{width:100%;display:block}#analyze-form select,#analyze-url{color:#000;padding:.5em;margin-bottom:1em;display:block;width:100%;font-size:16px;-webkit-appearance:none;-moz-appearance:none;appearance:none;-webkit-border-radius:7px;-moz-border-radius:7px;border-radius:7px;border:1px solid #dfdfdf;background:#fff}#analyze-url{width:100%}#analyze-form select{background:#fff url(../img/arrow_down.svg) right center /14px auto no-repeat}input[type=submit],button{font-size:18px;border:0 none;padding:.25em 1em;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;-webkit-appearance:none;-moz-appearance:none;appearance:none;cursor:pointer}#analyze-form input[type=submit]{background-color:#ffd100;float:right}#randomcats{overflow:hidden;margin:0 auto;position:relative}#randomtexts{padding-top:10px;padding-bottom:10px}#randomcats img{width:100%;height:auto;position:absolute;top:-9999px;bottom:-9999px;left:-9999px;right:-9999px;margin:auto}.result-button{color:#fff;margin:20px 0}#result-see-details{background-color:#da251d}#result-download{background-color:#0093dd}#stars{margin:10px 0 20px;letter-spacing:1vw}#bad-result #stars{color:#da251d}#good-result #stars{color:#e88829}#great-result #stars{color:#468847}#hero #stars{color:#468847}#share{overflow:hidden;padding:0}#share:before{width:130px;height:100px;display:block;content:\"\";background:transparent url(../img/cat/cat_share_this.svg) left center /contain no-repeat}#share li{float:left;padding:30px 1vw;width:15%;list-style-type:none}#share li a{display:block;height:40px;text-indent:-9999px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}#share .facebook a{background:#3b5998 url(../img/socialmedia/facebook.svg) center center /contain no-repeat}#share .twitter a{background:#00aced url(../img/socialmedia/twitter.svg) center center /contain no-repeat}#share .googleplus a{background:#dd4b39 url(../img/socialmedia/googleplus.svg) center center /contain no-repeat}#share .linkedin a{background:#007bb6 url(../img/socialmedia/linkedin.svg) center center /contain no-repeat}#share .pinterest a{background:#cb2027 url(../img/socialmedia/pinterest.svg) center center /contain no-repeat}@media only screen and (min-width:769px){body{border-top:48px solid #0095d2;background-color:#e1f6fd}#page,header,footer{width:100%;max-width:1280px;margin:0 auto}#page{padding-left:10px;min-height:300px;overflow:hidden}body:not(#start) #page:before{content:\"\";max-width:255px;max-height:255px;width:20vw;height:20vw;float:left}#content{margin:3% 20px 20px 21%;min-height:250px;-webkit-border-radius:10px;-moz-border-radius:10px;border-radius:10px;background-color:#e1f6fd;padding:20px;font-size:20px;line-height:1.5}#start #content{width:50%;min-width:550px;margin:0 auto;padding-top:150px}#dashboard #page:before{background:transparent url(../img/cat/dashboard.svg) 0 0 / contain no-repeat}#flash #page:before{background:transparent url(../img/cat/flash.svg) 0 0 / contain no-repeat}#extra #page:before{background:transparent url(../img/cat/cat_with_gears.svg) 0 0 / contain no-repeat}#faq #page:before{background:transparent url(../img/cat/magician.svg) 0 0 / contain no-repeat}#process #page:before{background:transparent url(../img/cat/cat_inspecting.svg) 0 0 / contain no-repeat}#bad-result #page:before{background:transparent url(../img/cat/cat_bad_result.svg) 0 0 / contain no-repeat}#good-result #page:before{background:transparent url(../img/cat/cat_good_result.svg) 0 0 / contain no-repeat}#hero #page:before{background:transparent url(../img/cat/captainSitespeed.io.svg) 0 0 / contain no-repeat}#top{width:100%;border-top:26px solid #0095d2;background-color:#fff;margin-right:50%;width:50%}header{background-color:#fff;border-top:36px solid #0095d2;margin-top:-62px;height:80px}header .homelink{background:#0095d2 url(../img/logos/logoHeader.svg) 10px 0 / 70% auto no-repeat;width:295px;height:62px;margin-top:-36px;margin-right:10px;position:relative;z-index:2}header .homelink:after{background:transparent url(../img/tabshape.svg) 0 0 / cover no-repeat;content:\"\";width:76px;height:28px;margin-top:34px;float:right;z-index:1}#analyze-form label{width:100%;padding-right:15%;display:block;overflow:hidden}#analyze-form span{float:left;padding-top:.5em;font-size:16px}#analyze-form input[type=submit]{margin-right:15%;font-size:24px}#analyze-form input[type=text]{font-size:24px}#analyze-form input[type=url]{font-size:24px}#analyze-form select{width:60%;float:right}#randomcats{width:71vw;height:32vw;max-width:100%;max-height:490px}#result-see-details{margin-right:10px}#stars{font-size:50px}#share:before{float:left}footer{height:72px;bottom:-72px;padding-left:10px;position:absolute;left:0;right:0}footer .homelink{max-width:215px;width:20%;height:100%;float:left}#footerlinks{padding:24px 10px 0 10px}#footershare li a{width:40px;height:40px}}@media only screen and (max-width:768px){body{font-size:16px;background-color:#0095d2}#page,header,.footerlist{max-width:100%}#page{overflow:hidden}#start #page{border:10px solid #0095d2}#content{margin-left:0;margin:10px 0 0;padding:13px}#container{background-color:#0095d2;padding-bottom:20px}#start #container{background-size:contain}#start #content{width:100%;padding-top:20vw;border:1vw solid #0095d2}body:not(#start) #page{-webkit-border-radius:10px 10px 0 0;-moz-border-radius:10px 10px 0 0;border-radius:10px 10px 0 0;background-color:#fff;margin:3vw 3vw 0;width:auto}#top{display:none}header .homelink{background:#0095d2 url(../img/logos/logoHeaderMobile.svg) center bottom / contain no-repeat;height:70px;border:10px solid #0095d2}h1{font-size:26px}#extra h1#box-title:after{background:transparent url(../img/cat/cat_with_gears.svg) center 0 / contain no-repeat}#dashboard h1#box-title:after{background:transparent url(../img/cat/dashboard.svg) center 0 / contain no-repeat}#flash h1#box-title:after{background:transparent url(../img/cat/flash.svg) center 0 / contain no-repeat}#faq h1#box-title:after{background:transparent url(../img/cat/magician.svg) center 0 / contain no-repeat}#extra h1#box-title:after{background:transparent url(../img/cat/cat_with_gears.svg) center 0 / contain no-repeat}#bad-result h1#box-title:after{background:transparent url(../img/cat/cat_bad_result.svg) center 0 / contain no-repeat}#good-result h1#box-title:after{background:transparent url(../img/cat/cat_good_result.svg) center 0 / contain no-repeat}#great-result h1#box-title:after{background:transparent url(../img/cat/cat_great_result.svg) center 0 / contain no-repeat}#hero h1#box-title:after{background:transparent url(../img/cat/captainSitespeed.io.svg) center 0 / contain no-repeat}#analyze-form{margin-bottom:3em}#analyze-form input[type=submit]{width:100%;padding:.5em 1em}#randomcats{width:87vw;height:39vw;margin-bottom:2vw}.resultpage #analyze-url{border-color:#bfe6f2;margin-bottom:3em}#stars{font-size:9vw}.result-button{width:45%;padding:1em}#result-download{float:right}#share:before{margin:0 auto}#share li{width:20%}#share li a{height:50px}footer{font-size:16px;overflow:hidden;margin-bottom:20px;text-align:center}body:not(#start) footer{margin:0 3vw 3vw;-webkit-border-radius:0 0 10px 10px;-moz-border-radius:0 0 10px 10px;border-radius:0 0 10px 10px}footer .homelink{bottom:0;left:0;margin:0 auto 7px;position:absolute;right:0;width:24%}#footershare{width:100%;float:none;padding:0}#footershare li{display:inline;float:none}#footershare li a{display:inline-block;margin:1em 0;width:60px;height:60px}#footerlinks{width:100%;height:auto;padding:0}#footerlinks li{width:100%;float:none;text-align:center;padding:1em;border-bottom:1px solid #bfe6f2}}</style></head><body id=start><script>!function(e,a,t,n,c,o,s){e.GoogleAnalyticsObject=c,e[c]=e[c]||function(){(e[c].q=e[c].q||[]).push(arguments)},e[c].l=1*new Date,o=a.createElement(t),s=a.getElementsByTagName(t)[0],o.async=1,o.src=n,s.parentNode.insertBefore(o,s)}(window,document,\"script\",\"//www.google-analytics.com/analytics.js\",\"ga\"),ga(\"create\",\"UA-31246987-3\",\"auto\"),ga(\"send\",\"pageview\");</script><div id=container><div id=page><div id=content><form id=analyze-form method=post action=\"/\"><input id=analyze-url name=url type=url required pattern=https?://.+ placeholder=\"http(s)://\" title=\"Add a URL starting with http(s)://\"><label><span>Browser:</span><select name=browser><option value=firefox selected=selected>Firefox [41]</option><option value=chrome>Chrome [45]</option></select></label><label><span>Location:</span><select name=location><option value=nyc>New York [USA]</option><option value=sf>San Francisco [USA]</option><option value=amsterdam>Amsterdam [Netherlands]</option><option value=singapore>Singapore [Singapore]</option></select></label><label><span>Connection type:</span><select name=connection><option value=mobile3g>mobile3g</option><option value=mobile3gfast>mobile3g fast</option><option value=cable selected=selected>cable</option><option value=native>native</option></select></label><input type=submit value=\"Start analyzing\"></form></div></div><footer><a class=homelink href=\"/\">Sitespeed.io</a><ul id=footerlinks class=footerlist><li><a href=\"/\">Home</a></li><li><a href=\"/about/\">About</a></li><li><a href=\"/sponsors/\">Sponsors</a></li><li><a href=\"/dashboard/\">Dashboard</a></li><li><a href=\"/faq/\">FAQ</a></li></ul><ul id=footershare class=\"socialcount footerlist\"><li class=facebook><a href=https://www.facebook.com/sitespeed.io title=\"Like on Facebook\"></a></li><li class=twitter><a href=https://twitter.com/sitespeedio title=\"Follow on Twitter\"></a></li><li class=github><a href=https://github.com/sitespeedio/sitespeed.io title=\"Star on Github\"></a></li></ul></footer></div></body></html>"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 4019
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.421999982791021,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.20000000949949093,
+          "wait": 114.40699998638549,
+          "receive": 2.0070000027776445,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.313Z",
+        "time": 6.945999979507178,
+        "request": {
+          "method": "GET",
+          "url": "https://www.google-analytics.com/analytics.js",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/analytics.js"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "www.google-analytics.com"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:18:44 GMT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "last-modified",
+              "value": "Thu, 05 Nov 2015 22:24:16 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Golfe2"
+            },
+            {
+              "name": "age",
+              "value": "1662"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-type",
+              "value": "text/javascript"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=7200"
+            },
+            {
+              "name": "content-length",
+              "value": "10930"
+            },
+            {
+              "name": "expires",
+              "value": "Tue, 19 Jan 2016 08:18:44 GMT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 26285,
+            "mimeType": "text/javascript",
+            "text": "(function(){var $c=function(a){this.w=a||[]};$c.prototype.set=function(a){this.w[a]=!0};$c.prototype.encode=function(){for(var a=[],b=0;b<this.w.length;b++)this.w[b]&&(a[Math.floor(b/6)]^=1<<b%6);for(b=0;b<a.length;b++)a[b]=\"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_\".charAt(a[b]||0);return a.join(\"\")+\"~\"};var vd=new $c;function J(a){vd.set(a)}var Nd=function(a,b){var c=new $c(Dd(a));c.set(b);a.set(Gd,c.w)},Td=function(a){a=Dd(a);a=new $c(a);for(var b=vd.w.slice(),c=0;c<a.w.length;c++)b[c]=b[c]||a.w[c];return(new $c(b)).encode()},Dd=function(a){a=a.get(Gd);ka(a)||(a=[]);return a};var ea=function(a){return\"function\"==typeof a},ka=function(a){return\"[object Array]\"==Object.prototype.toString.call(Object(a))},qa=function(a){return void 0!=a&&-1<(a.constructor+\"\").indexOf(\"String\")},D=function(a,b){return 0==a.indexOf(b)},sa=function(a){return a?a.replace(/^[\\s\\xa0]+|[\\s\\xa0]+$/g,\"\"):\"\"},ta=function(a){var b=M.createElement(\"img\");b.width=1;b.height=1;b.src=a;return b},ua=function(){},K=function(a){if(encodeURIComponent instanceof Function)return encodeURIComponent(a);J(28);return a},\nL=function(a,b,c,d){try{a.addEventListener?a.addEventListener(b,c,!!d):a.attachEvent&&a.attachEvent(\"on\"+b,c)}catch(e){J(27)}},wa=function(a,b){if(a){var c=M.createElement(\"script\");c.type=\"text/javascript\";c.async=!0;c.src=a;b&&(c.id=b);var d=M.getElementsByTagName(\"script\")[0];d.parentNode.insertBefore(c,d)}},Ud=function(){return\"https:\"==M.location.protocol},xa=function(){var a=\"\"+M.location.hostname;return 0==a.indexOf(\"www.\")?a.substring(4):a},ya=function(a){var b=M.referrer;if(/^https?:\\/\\//i.test(b)){if(a)return b;\na=\"//\"+M.location.hostname;var c=b.indexOf(a);if(5==c||6==c)if(a=b.charAt(c+a.length),\"/\"==a||\"?\"==a||\"\"==a||\":\"==a)return;return b}},za=function(a,b){if(1==b.length&&null!=b[0]&&\"object\"===typeof b[0])return b[0];for(var c={},d=Math.min(a.length+1,b.length),e=0;e<d;e++)if(\"object\"===typeof b[e]){for(var g in b[e])b[e].hasOwnProperty(g)&&(c[g]=b[e][g]);break}else e<a.length&&(c[a[e]]=b[e]);return c};var ee=function(){this.keys=[];this.values={};this.m={}};ee.prototype.set=function(a,b,c){this.keys.push(a);c?this.m[\":\"+a]=b:this.values[\":\"+a]=b};ee.prototype.get=function(a){return this.m.hasOwnProperty(\":\"+a)?this.m[\":\"+a]:this.values[\":\"+a]};ee.prototype.map=function(a){for(var b=0;b<this.keys.length;b++){var c=this.keys[b],d=this.get(c);d&&a(c,d)}};var O=window,M=document;var Aa=function(a){var b=O._gaUserPrefs;if(b&&b.ioo&&b.ioo()||a&&!0===O[\"ga-disable-\"+a])return!0;try{var c=O.external;if(c&&c._gaUserPrefs&&\"oo\"==c._gaUserPrefs)return!0}catch(d){}return!1};var Ca=function(a){var b=[],c=M.cookie.split(\";\");a=new RegExp(\"^\\\\s*\"+a+\"=\\\\s*(.*?)\\\\s*$\");for(var d=0;d<c.length;d++){var e=c[d].match(a);e&&b.push(e[1])}return b},zc=function(a,b,c,d,e,g){e=Aa(e)?!1:eb.test(M.location.hostname)||\"/\"==c&&vc.test(d)?!1:!0;if(!e)return!1;b&&1200<b.length&&(b=b.substring(0,1200),J(24));c=a+\"=\"+b+\"; path=\"+c+\"; \";g&&(c+=\"expires=\"+(new Date((new Date).getTime()+g)).toGMTString()+\"; \");d&&\"none\"!=d&&(c+=\"domain=\"+d+\";\");d=M.cookie;M.cookie=c;if(!(d=d!=M.cookie))a:{a=\nCa(a);for(d=0;d<a.length;d++)if(b==a[d]){d=!0;break a}d=!1}return d},Cc=function(a){return K(a).replace(/\\(/g,\"%28\").replace(/\\)/g,\"%29\")},vc=/^(www\\.)?google(\\.com?)?(\\.[a-z]{2})?$/,eb=/(^|\\.)doubleclick\\.net$/i;var oc=function(){return(Ba||Ud()?\"https:\":\"http:\")+\"//www.google-analytics.com\"},Da=function(a){this.name=\"len\";this.message=a+\"-8192\"},ba=function(a,b,c){c=c||ua;if(2036>=b.length)wc(a,b,c);else if(8192>=b.length)x(a,b,c)||wd(a,b,c)||wc(a,b,c);else throw ge(\"len\",b.length),new Da(b.length);},wc=function(a,b,c){var d=ta(a+\"?\"+b);d.onload=d.onerror=function(){d.onload=null;d.onerror=null;c()}},wd=function(a,b,c){var d=O.XMLHttpRequest;if(!d)return!1;var e=new d;if(!(\"withCredentials\"in e))return!1;\ne.open(\"POST\",a,!0);e.withCredentials=!0;e.setRequestHeader(\"Content-Type\",\"text/plain\");e.onreadystatechange=function(){4==e.readyState&&(c(),e=null)};e.send(b);return!0},x=function(a,b,c){return O.navigator.sendBeacon?O.navigator.sendBeacon(a,b)?(c(),!0):!1:!1},ge=function(a,b,c){1<=100*Math.random()||Aa(\"?\")||(a=[\"t=error\",\"_e=\"+a,\"_v=j40\",\"sr=1\"],b&&a.push(\"_f=\"+b),c&&a.push(\"_m=\"+K(c.substring(0,100))),a.push(\"aip=1\"),a.push(\"z=\"+hd()),wc(oc()+\"/collect\",a.join(\"&\"),ua))};var Ha=function(){this.M=[]};Ha.prototype.add=function(a){this.M.push(a)};Ha.prototype.D=function(a){try{for(var b=0;b<this.M.length;b++){var c=a.get(this.M[b]);c&&ea(c)&&c.call(O,a)}}catch(d){}b=a.get(Ia);b!=ua&&ea(b)&&(a.set(Ia,ua,!0),setTimeout(b,10))};function Ja(a){if(100!=a.get(Ka)&&La(P(a,Q))%1E4>=100*R(a,Ka))throw\"abort\";}function Ma(a){if(Aa(P(a,Na)))throw\"abort\";}function Oa(){var a=M.location.protocol;if(\"http:\"!=a&&\"https:\"!=a)throw\"abort\";}\nfunction Pa(a){try{O.navigator.sendBeacon?J(42):O.XMLHttpRequest&&\"withCredentials\"in new O.XMLHttpRequest&&J(40)}catch(c){}a.set(ld,Td(a),!0);a.set(Ac,R(a,Ac)+1);var b=[];Qa.map(function(c,d){if(d.F){var e=a.get(c);void 0!=e&&e!=d.defaultValue&&(\"boolean\"==typeof e&&(e*=1),b.push(d.F+\"=\"+K(\"\"+e)))}});b.push(\"z=\"+Bd());a.set(Ra,b.join(\"&\"),!0)}\nfunction Sa(a){var b=P(a,gd)||oc()+\"/collect\",c=P(a,fa);!c&&a.get(Vd)&&(c=\"beacon\");if(c){var d=P(a,Ra),e=a.get(Ia),e=e||ua;\"image\"==c?wc(b,d,e):\"xhr\"==c&&wd(b,d,e)||\"beacon\"==c&&x(b,d,e)||ba(b,d,e)}else ba(b,P(a,Ra),a.get(Ia));a.set(Ia,ua,!0)}function Hc(a){var b=O.gaData;b&&(b.expId&&a.set(Nc,b.expId),b.expVar&&a.set(Oc,b.expVar))}function cd(){if(O.navigator&&\"preview\"==O.navigator.loadPurpose)throw\"abort\";}function yd(a){var b=O.gaDevIds;ka(b)&&0!=b.length&&a.set(\"&did\",b.join(\",\"),!0)}\nfunction vb(a){if(!a.get(Na))throw\"abort\";};var hd=function(){return Math.round(2147483647*Math.random())},Bd=function(){try{var a=new Uint32Array(1);O.crypto.getRandomValues(a);return a[0]&2147483647}catch(b){return hd()}};function Ta(a){var b=R(a,Ua);500<=b&&J(15);var c=P(a,Va);if(\"transaction\"!=c&&\"item\"!=c){var c=R(a,Wa),d=(new Date).getTime(),e=R(a,Xa);0==e&&a.set(Xa,d);e=Math.round(2*(d-e)/1E3);0<e&&(c=Math.min(c+e,20),a.set(Xa,d));if(0>=c)throw\"abort\";a.set(Wa,--c)}a.set(Ua,++b)};var Ya=function(){this.data=new ee},Qa=new ee,Za=[];Ya.prototype.get=function(a){var b=$a(a),c=this.data.get(a);b&&void 0==c&&(c=ea(b.defaultValue)?b.defaultValue():b.defaultValue);return b&&b.Z?b.Z(this,a,c):c};var P=function(a,b){var c=a.get(b);return void 0==c?\"\":\"\"+c},R=function(a,b){var c=a.get(b);return void 0==c||\"\"===c?0:1*c};Ya.prototype.set=function(a,b,c){if(a)if(\"object\"==typeof a)for(var d in a)a.hasOwnProperty(d)&&ab(this,d,a[d],c);else ab(this,a,b,c)};\nvar ab=function(a,b,c,d){if(void 0!=c)switch(b){case Na:wb.test(c)}var e=$a(b);e&&e.o?e.o(a,b,c,d):a.data.set(b,c,d)},bb=function(a,b,c,d,e){this.name=a;this.F=b;this.Z=d;this.o=e;this.defaultValue=c},$a=function(a){var b=Qa.get(a);if(!b)for(var c=0;c<Za.length;c++){var d=Za[c],e=d[0].exec(a);if(e){b=d[1](e);Qa.set(b.name,b);break}}return b},yc=function(a){var b;Qa.map(function(c,d){d.F==a&&(b=d)});return b&&b.name},S=function(a,b,c,d,e){a=new bb(a,b,c,d,e);Qa.set(a.name,a);return a.name},cb=function(a,\nb){Za.push([new RegExp(\"^\"+a+\"$\"),b])},T=function(a,b,c){return S(a,b,c,void 0,db)},db=function(){};var gb=qa(window.GoogleAnalyticsObject)&&sa(window.GoogleAnalyticsObject)||\"ga\",Ba=!1,he=S(\"_br\"),hb=T(\"apiVersion\",\"v\"),ib=T(\"clientVersion\",\"_v\");S(\"anonymizeIp\",\"aip\");var jb=S(\"adSenseId\",\"a\"),Va=S(\"hitType\",\"t\"),Ia=S(\"hitCallback\"),Ra=S(\"hitPayload\");S(\"nonInteraction\",\"ni\");S(\"currencyCode\",\"cu\");S(\"dataSource\",\"ds\");var Vd=S(\"useBeacon\",void 0,!1),fa=S(\"transport\");S(\"sessionControl\",\"sc\",\"\");S(\"sessionGroup\",\"sg\");S(\"queueTime\",\"qt\");var Ac=S(\"_s\",\"_s\");S(\"screenName\",\"cd\");\nvar kb=S(\"location\",\"dl\",\"\"),lb=S(\"referrer\",\"dr\"),mb=S(\"page\",\"dp\",\"\");S(\"hostname\",\"dh\");var nb=S(\"language\",\"ul\"),ob=S(\"encoding\",\"de\");S(\"title\",\"dt\",function(){return M.title||void 0});cb(\"contentGroup([0-9]+)\",function(a){return new bb(a[0],\"cg\"+a[1])});var pb=S(\"screenColors\",\"sd\"),qb=S(\"screenResolution\",\"sr\"),rb=S(\"viewportSize\",\"vp\"),sb=S(\"javaEnabled\",\"je\"),tb=S(\"flashVersion\",\"fl\");S(\"campaignId\",\"ci\");S(\"campaignName\",\"cn\");S(\"campaignSource\",\"cs\");S(\"campaignMedium\",\"cm\");\nS(\"campaignKeyword\",\"ck\");S(\"campaignContent\",\"cc\");var ub=S(\"eventCategory\",\"ec\"),xb=S(\"eventAction\",\"ea\"),yb=S(\"eventLabel\",\"el\"),zb=S(\"eventValue\",\"ev\"),Bb=S(\"socialNetwork\",\"sn\"),Cb=S(\"socialAction\",\"sa\"),Db=S(\"socialTarget\",\"st\"),Eb=S(\"l1\",\"plt\"),Fb=S(\"l2\",\"pdt\"),Gb=S(\"l3\",\"dns\"),Hb=S(\"l4\",\"rrt\"),Ib=S(\"l5\",\"srt\"),Jb=S(\"l6\",\"tcp\"),Kb=S(\"l7\",\"dit\"),Lb=S(\"l8\",\"clt\"),Mb=S(\"timingCategory\",\"utc\"),Nb=S(\"timingVar\",\"utv\"),Ob=S(\"timingLabel\",\"utl\"),Pb=S(\"timingValue\",\"utt\");S(\"appName\",\"an\");\nS(\"appVersion\",\"av\",\"\");S(\"appId\",\"aid\",\"\");S(\"appInstallerId\",\"aiid\",\"\");S(\"exDescription\",\"exd\");S(\"exFatal\",\"exf\");var Nc=S(\"expId\",\"xid\"),Oc=S(\"expVar\",\"xvar\"),Rc=S(\"_utma\",\"_utma\"),Sc=S(\"_utmz\",\"_utmz\"),Tc=S(\"_utmht\",\"_utmht\"),Ua=S(\"_hc\",void 0,0),Xa=S(\"_ti\",void 0,0),Wa=S(\"_to\",void 0,20);cb(\"dimension([0-9]+)\",function(a){return new bb(a[0],\"cd\"+a[1])});cb(\"metric([0-9]+)\",function(a){return new bb(a[0],\"cm\"+a[1])});S(\"linkerParam\",void 0,void 0,Bc,db);var ld=S(\"usage\",\"_u\"),Gd=S(\"_um\");\nS(\"forceSSL\",void 0,void 0,function(){return Ba},function(a,b,c){J(34);Ba=!!c});var ed=S(\"_j1\",\"jid\");cb(\"\\\\&(.*)\",function(a){var b=new bb(a[0],a[1]),c=yc(a[0].substring(1));c&&(b.Z=function(a){return a.get(c)},b.o=function(a,b,g,ca){a.set(c,g,ca)},b.F=void 0);return b});\nvar Qb=T(\"_oot\"),dd=S(\"previewTask\"),Rb=S(\"checkProtocolTask\"),md=S(\"validationTask\"),Sb=S(\"checkStorageTask\"),Uc=S(\"historyImportTask\"),Tb=S(\"samplerTask\"),Vb=S(\"_rlt\"),Wb=S(\"buildHitTask\"),Xb=S(\"sendHitTask\"),Vc=S(\"ceTask\"),zd=S(\"devIdTask\"),Cd=S(\"timingTask\"),Ld=S(\"displayFeaturesTask\"),V=T(\"name\"),Q=T(\"clientId\",\"cid\"),Ad=S(\"userId\",\"uid\"),Na=T(\"trackingId\",\"tid\"),U=T(\"cookieName\",void 0,\"_ga\"),W=T(\"cookieDomain\"),Yb=T(\"cookiePath\",void 0,\"/\"),Zb=T(\"cookieExpires\",void 0,63072E3),$b=T(\"legacyCookieDomain\"),\nWc=T(\"legacyHistoryImport\",void 0,!0),ac=T(\"storage\",void 0,\"cookie\"),bc=T(\"allowLinker\",void 0,!1),cc=T(\"allowAnchor\",void 0,!0),Ka=T(\"sampleRate\",\"sf\",100),dc=T(\"siteSpeedSampleRate\",void 0,1),ec=T(\"alwaysSendReferrer\",void 0,!1),gd=S(\"transportUrl\"),Md=S(\"_r\",\"_r\");function X(a,b,c,d){b[a]=function(){try{return d&&J(d),c.apply(this,arguments)}catch(b){throw ge(\"exc\",a,b&&b.name),b;}}};var Od=function(a,b,c){this.V=1E4;this.fa=a;this.$=!1;this.B=b;this.ea=c||1},Ed=function(a,b){var c;if(a.fa&&a.$)return 0;a.$=!0;if(b){if(a.B&&R(b,a.B))return R(b,a.B);if(0==b.get(dc))return 0}if(0==a.V)return 0;void 0===c&&(c=Bd());return 0==c%a.V?Math.floor(c/a.V)%a.ea+1:0};var ie=new Od(!0,he,7),je=function(a){if(!Ud()&&!Ba){var b=Ed(ie,a);if(b&&!(!O.navigator.sendBeacon&&4<=b&&6>=b)){var c=(new Date).getHours(),d=[Bd(),Bd(),Bd()].join(\".\");a=(3==b||5==b?\"https:\":\"http:\")+\"//www.google-analytics.com/collect?z=br.\";a+=[b,\"A\",c,d].join(\".\");var e=1!=b%3?\"https:\":\"http:\",e=e+\"//www.google-analytics.com/collect?z=br.\",e=e+[b,\"B\",c,d].join(\".\");7==b&&(e=e.replace(\"//www.\",\"//ssl.\"));c=function(){4<=b&&6>=b?O.navigator.sendBeacon(e,\"\"):ta(e)};Bd()%2?(ta(a),c()):(c(),ta(a))}}};function fc(){var a,b,c;if((c=(c=O.navigator)?c.plugins:null)&&c.length)for(var d=0;d<c.length&&!b;d++){var e=c[d];-1<e.name.indexOf(\"Shockwave Flash\")&&(b=e.description)}if(!b)try{a=new ActiveXObject(\"ShockwaveFlash.ShockwaveFlash.7\"),b=a.GetVariable(\"$version\")}catch(g){}if(!b)try{a=new ActiveXObject(\"ShockwaveFlash.ShockwaveFlash.6\"),b=\"WIN 6,0,21,0\",a.AllowScriptAccess=\"always\",b=a.GetVariable(\"$version\")}catch(g){}if(!b)try{a=new ActiveXObject(\"ShockwaveFlash.ShockwaveFlash\"),b=a.GetVariable(\"$version\")}catch(g){}b&&\n(a=b.match(/[\\d]+/g))&&3<=a.length&&(b=a[0]+\".\"+a[1]+\" r\"+a[2]);return b||void 0};var gc=function(a,b){var c=Math.min(R(a,dc),100);if(!(La(P(a,Q))%100>=c)&&(c={},Ec(c)||Fc(c))){var d=c[Eb];void 0==d||Infinity==d||isNaN(d)||(0<d?(Y(c,Gb),Y(c,Jb),Y(c,Ib),Y(c,Fb),Y(c,Hb),Y(c,Kb),Y(c,Lb),b(c)):L(O,\"load\",function(){gc(a,b)},!1))}},Ec=function(a){var b=O.performance||O.webkitPerformance,b=b&&b.timing;if(!b)return!1;var c=b.navigationStart;if(0==c)return!1;a[Eb]=b.loadEventStart-c;a[Gb]=b.domainLookupEnd-b.domainLookupStart;a[Jb]=b.connectEnd-b.connectStart;a[Ib]=b.responseStart-b.requestStart;\na[Fb]=b.responseEnd-b.responseStart;a[Hb]=b.fetchStart-c;a[Kb]=b.domInteractive-c;a[Lb]=b.domContentLoadedEventStart-c;return!0},Fc=function(a){if(O.top!=O)return!1;var b=O.external,c=b&&b.onloadT;b&&!b.isValidLoadTime&&(c=void 0);2147483648<c&&(c=void 0);0<c&&b.setPageReadyTime();if(void 0==c)return!1;a[Eb]=c;return!0},Y=function(a,b){var c=a[b];if(isNaN(c)||Infinity==c||0>c)a[b]=void 0},Fd=function(a){return function(b){\"pageview\"!=b.get(Va)||a.I||(a.I=!0,gc(b,function(b){a.send(\"timing\",b)}))}};var hc=!1,mc=function(a){if(\"cookie\"==P(a,ac)){var b=P(a,U),c=nd(a),d=kc(P(a,Yb)),e=lc(P(a,W)),g=1E3*R(a,Zb),ca=P(a,Na);if(\"auto\"!=e)zc(b,c,d,e,ca,g)&&(hc=!0);else{J(32);var l;a:{c=[];e=xa().split(\".\");if(4==e.length&&(l=e[e.length-1],parseInt(l,10)==l)){l=[\"none\"];break a}for(l=e.length-2;0<=l;l--)c.push(e.slice(l).join(\".\"));c.push(\"none\");l=c}for(var k=0;k<l.length;k++)if(e=l[k],a.data.set(W,e),c=nd(a),zc(b,c,d,e,ca,g)){hc=!0;return}a.data.set(W,\"auto\")}}},nc=function(a){if(\"cookie\"==P(a,ac)&&\n!hc&&(mc(a),!hc))throw\"abort\";},Yc=function(a){if(a.get(Wc)){var b=P(a,W),c=P(a,$b)||xa(),d=Xc(\"__utma\",c,b);d&&(J(19),a.set(Tc,(new Date).getTime(),!0),a.set(Rc,d.R),(b=Xc(\"__utmz\",c,b))&&d.hash==b.hash&&a.set(Sc,b.R))}},nd=function(a){var b=Cc(P(a,Q)),c=ic(P(a,W));a=jc(P(a,Yb));1<a&&(c+=\"-\"+a);return[\"GA1\",c,b].join(\".\")},Gc=function(a,b,c){for(var d=[],e=[],g,ca=0;ca<a.length;ca++){var l=a[ca];l.H[c]==b?d.push(l):void 0==g||l.H[c]<g?(e=[l],g=l.H[c]):l.H[c]==g&&e.push(l)}return 0<d.length?d:e},\nlc=function(a){return 0==a.indexOf(\".\")?a.substr(1):a},ic=function(a){return lc(a).split(\".\").length},kc=function(a){if(!a)return\"/\";1<a.length&&a.lastIndexOf(\"/\")==a.length-1&&(a=a.substr(0,a.length-1));0!=a.indexOf(\"/\")&&(a=\"/\"+a);return a},jc=function(a){a=kc(a);return\"/\"==a?1:a.split(\"/\").length};function Xc(a,b,c){\"none\"==b&&(b=\"\");var d=[],e=Ca(a);a=\"__utma\"==a?6:2;for(var g=0;g<e.length;g++){var ca=(\"\"+e[g]).split(\".\");ca.length>=a&&d.push({hash:ca[0],R:e[g],O:ca})}return 0==d.length?void 0:1==d.length?d[0]:Zc(b,d)||Zc(c,d)||Zc(null,d)||d[0]}function Zc(a,b){var c,d;null==a?c=d=1:(c=La(a),d=La(D(a,\".\")?a.substring(1):\".\"+a));for(var e=0;e<b.length;e++)if(b[e].hash==c||b[e].hash==d)return b[e]};var od=new RegExp(/^https?:\\/\\/([^\\/:]+)/),pd=/(.*)([?&#])(?:_ga=[^&#]*)(?:&?)(.*)/;function Bc(a){a=a.get(Q);var b=Ic(a,0);return\"_ga=1.\"+K(b+\".\"+a)}function Ic(a,b){for(var c=new Date,d=O.navigator,e=d.plugins||[],c=[a,d.userAgent,c.getTimezoneOffset(),c.getYear(),c.getDate(),c.getHours(),c.getMinutes()+b],d=0;d<e.length;++d)c.push(e[d].description);return La(c.join(\".\"))}var Dc=function(a){J(48);this.target=a;this.T=!1};\nDc.prototype.ca=function(a,b){if(a.tagName){if(\"a\"==a.tagName.toLowerCase()){a.href&&(a.href=qd(this,a.href,b));return}if(\"form\"==a.tagName.toLowerCase())return rd(this,a)}if(\"string\"==typeof a)return qd(this,a,b)};\nvar qd=function(a,b,c){var d=pd.exec(b);d&&3<=d.length&&(b=d[1]+(d[3]?d[2]+d[3]:\"\"));a=a.target.get(\"linkerParam\");var e=b.indexOf(\"?\"),d=b.indexOf(\"#\");c?b+=(-1==d?\"#\":\"&\")+a:(c=-1==e?\"?\":\"&\",b=-1==d?b+(c+a):b.substring(0,d)+c+a+b.substring(d));return b=b.replace(/&+_ga=/,\"&_ga=\")},rd=function(a,b){if(b&&b.action){var c=a.target.get(\"linkerParam\").split(\"=\")[1];if(\"get\"==b.method.toLowerCase()){for(var d=b.childNodes||[],e=0;e<d.length;e++)if(\"_ga\"==d[e].name){d[e].setAttribute(\"value\",c);return}d=\nM.createElement(\"input\");d.setAttribute(\"type\",\"hidden\");d.setAttribute(\"name\",\"_ga\");d.setAttribute(\"value\",c);b.appendChild(d)}else\"post\"==b.method.toLowerCase()&&(b.action=qd(a,b.action))}};\nDc.prototype.S=function(a,b,c){function d(c){try{c=c||O.event;var d;a:{var g=c.target||c.srcElement;for(c=100;g&&0<c;){if(g.href&&g.nodeName.match(/^a(?:rea)?$/i)){d=g;break a}g=g.parentNode;c--}d={}}(\"http:\"==d.protocol||\"https:\"==d.protocol)&&sd(a,d.hostname||\"\")&&d.href&&(d.href=qd(e,d.href,b))}catch(w){J(26)}}var e=this;this.T||(this.T=!0,L(M,\"mousedown\",d,!1),L(M,\"keyup\",d,!1));if(c){c=function(b){b=b||O.event;if((b=b.target||b.srcElement)&&b.action){var c=b.action.match(od);c&&sd(a,c[1])&&rd(e,\nb)}};for(var g=0;g<M.forms.length;g++)L(M.forms[g],\"submit\",c)}};function sd(a,b){if(b==M.location.hostname)return!1;for(var c=0;c<a.length;c++)if(a[c]instanceof RegExp){if(a[c].test(b))return!0}else if(0<=b.indexOf(a[c]))return!0;return!1};var Jd=function(a,b,c){this.U=ed;this.aa=b;(b=c)||(b=(b=P(a,V))&&\"t0\"!=b?Wd.test(b)?\"_gat_\"+Cc(P(a,Na)):\"_gat_\"+Cc(b):\"_gat\");this.Y=b},Rd=function(a,b){var c=b.get(Wb);b.set(Wb,function(b){Pd(a,b);var d=c(b);Qd(a,b);return d});var d=b.get(Xb);b.set(Xb,function(b){var c=d(b);Id(a,b);return c})},Pd=function(a,b){b.get(a.U)||(\"1\"==Ca(a.Y)[0]?b.set(a.U,\"\",!0):b.set(a.U,\"\"+hd(),!0))},Qd=function(a,b){b.get(a.U)&&zc(a.Y,\"1\",b.get(Yb),b.get(W),b.get(Na),6E5)},Id=function(a,b){if(b.get(a.U)){var c=new ee,\nd=function(a){$a(a).F&&c.set($a(a).F,b.get(a))};d(hb);d(ib);d(Na);d(Q);d(a.U);c.set($a(ld).F,Td(b));var e=a.aa;c.map(function(a,b){e+=K(a)+\"=\";e+=K(\"\"+b)+\"&\"});e+=\"z=\"+hd();ta(e);b.set(a.U,\"\",!0)}},Wd=/^gtm\\d+$/;var fd=function(a,b){var c=a.b;if(!c.get(\"dcLoaded\")){Nd(c,29);b=b||{};var d;b[U]&&(d=Cc(b[U]));d=new Jd(c,\"https://stats.g.doubleclick.net/r/collect?t=dc&aip=1&_r=3&\",d);Rd(d,c);c.set(\"dcLoaded\",!0)}};var Sd=function(a){if(!a.get(\"dcLoaded\")&&\"cookie\"==a.get(ac)){Nd(a,51);var b=new Jd(a);Pd(b,a);Qd(b,a);a.get(b.U)&&(a.set(Md,1,!0),a.set(gd,oc()+\"/r/collect\",!0))}};var Lc=function(){var a=O.gaGlobal=O.gaGlobal||{};return a.hid=a.hid||hd()};var ad,bd=function(a,b,c){if(!ad){var d;d=M.location.hash;var e=O.name,g=/^#?gaso=([^&]*)/;if(e=(d=(d=d&&d.match(g)||e&&e.match(g))?d[1]:Ca(\"GASO\")[0]||\"\")&&d.match(/^(?:!([-0-9a-z.]{1,40})!)?([-.\\w]{10,1200})$/i))zc(\"GASO\",\"\"+d,c,b,a,0),window._udo||(window._udo=b),window._utcp||(window._utcp=c),a=e[1],wa(\"https://www.google.com/analytics/web/inpage/pub/inpage.js?\"+(a?\"prefix=\"+a+\"&\":\"\")+hd(),\"_gasojs\");ad=!0}};var wb=/^(UA|YT|MO|GP)-(\\d+)-(\\d+)$/,pc=function(a){function b(a,b){d.b.data.set(a,b)}function c(a,c){b(a,c);d.filters.add(a)}var d=this;this.b=new Ya;this.filters=new Ha;b(V,a[V]);b(Na,sa(a[Na]));b(U,a[U]);b(W,a[W]||xa());b(Yb,a[Yb]);b(Zb,a[Zb]);b($b,a[$b]);b(Wc,a[Wc]);b(bc,a[bc]);b(cc,a[cc]);b(Ka,a[Ka]);b(dc,a[dc]);b(ec,a[ec]);b(ac,a[ac]);b(Ad,a[Ad]);b(hb,1);b(ib,\"j40\");c(Qb,Ma);c(dd,cd);c(Rb,Oa);c(md,vb);c(Sb,nc);c(Uc,Yc);c(Tb,Ja);c(Vb,Ta);c(Vc,Hc);c(zd,yd);c(Ld,Sd);c(Wb,Pa);c(Xb,Sa);c(Cd,Fd(this));\nJc(this.b,a[Q]);Kc(this.b);this.b.set(jb,Lc());bd(this.b.get(Na),this.b.get(W),this.b.get(Yb))},Jc=function(a,b){if(\"cookie\"==P(a,ac)){hc=!1;var c;b:{var d=Ca(P(a,U));if(d&&!(1>d.length)){c=[];for(var e=0;e<d.length;e++){var g;g=d[e].split(\".\");var ca=g.shift();(\"GA1\"==ca||\"1\"==ca)&&1<g.length?(ca=g.shift().split(\"-\"),1==ca.length&&(ca[1]=\"1\"),ca[0]*=1,ca[1]*=1,g={H:ca,s:g.join(\".\")}):g=void 0;g&&c.push(g)}if(1==c.length){J(13);c=c[0].s;break b}if(0==c.length)J(12);else{J(14);d=ic(P(a,W));c=Gc(c,\nd,0);if(1==c.length){c=c[0].s;break b}d=jc(P(a,Yb));c=Gc(c,d,1);c=c[0]&&c[0].s;break b}}c=void 0}c||(c=P(a,W),d=P(a,$b)||xa(),c=Xc(\"__utma\",d,c),void 0!=c?(J(10),c=c.O[1]+\".\"+c.O[2]):c=void 0);c&&(a.data.set(Q,c),hc=!0)}c=a.get(cc);if(e=(c=M.location[c?\"href\":\"search\"].match(\"(?:&|#|\\\\?)\"+K(\"_ga\").replace(/([.*+?^=!:${}()|\\[\\]\\/\\\\])/g,\"\\\\$1\")+\"=([^&#]*)\"))&&2==c.length?c[1]:\"\")a.get(bc)?(c=e.indexOf(\".\"),-1==c?J(22):(d=e.substring(c+1),\"1\"!=e.substring(0,c)?J(22):(c=d.indexOf(\".\"),-1==c?J(22):(e=\nd.substring(0,c),c=d.substring(c+1),e!=Ic(c,0)&&e!=Ic(c,-1)&&e!=Ic(c,-2)?J(23):(J(11),a.data.set(Q,c)))))):J(21);b&&(J(9),a.data.set(Q,K(b)));if(!a.get(Q))if(c=(c=O.gaGlobal&&O.gaGlobal.vid)&&-1!=c.search(/^(?:utma\\.)?\\d+\\.\\d+$/)?c:void 0)J(17),a.data.set(Q,c);else{J(8);c=O.navigator.userAgent+(M.cookie?M.cookie:\"\")+(M.referrer?M.referrer:\"\");d=c.length;for(e=O.history.length;0<e;)c+=e--^d++;a.data.set(Q,[hd()^La(c)&2147483647,Math.round((new Date).getTime()/1E3)].join(\".\"))}mc(a)},Kc=function(a){var b=\nO.navigator,c=O.screen,d=M.location;a.set(lb,ya(a.get(ec)));if(d){var e=d.pathname||\"\";\"/\"!=e.charAt(0)&&(J(31),e=\"/\"+e);a.set(kb,d.protocol+\"//\"+d.hostname+e+d.search)}c&&a.set(qb,c.width+\"x\"+c.height);c&&a.set(pb,c.colorDepth+\"-bit\");var c=M.documentElement,g=(e=M.body)&&e.clientWidth&&e.clientHeight,ca=[];c&&c.clientWidth&&c.clientHeight&&(\"CSS1Compat\"===M.compatMode||!g)?ca=[c.clientWidth,c.clientHeight]:g&&(ca=[e.clientWidth,e.clientHeight]);c=0>=ca[0]||0>=ca[1]?\"\":ca.join(\"x\");a.set(rb,c);a.set(tb,\nfc());a.set(ob,M.characterSet||M.charset);a.set(sb,b&&\"function\"===typeof b.javaEnabled&&b.javaEnabled()||!1);a.set(nb,(b&&(b.language||b.browserLanguage)||\"\").toLowerCase());if(d&&a.get(cc)&&(b=M.location.hash)){b=b.split(/[?&#]+/);d=[];for(c=0;c<b.length;++c)(D(b[c],\"utm_id\")||D(b[c],\"utm_campaign\")||D(b[c],\"utm_source\")||D(b[c],\"utm_medium\")||D(b[c],\"utm_term\")||D(b[c],\"utm_content\")||D(b[c],\"gclid\")||D(b[c],\"dclid\")||D(b[c],\"gclsrc\"))&&d.push(b[c]);0<d.length&&(b=\"#\"+d.join(\"&\"),a.set(kb,a.get(kb)+\nb))}};pc.prototype.get=function(a){return this.b.get(a)};pc.prototype.set=function(a,b){this.b.set(a,b)};var qc={pageview:[mb],event:[ub,xb,yb,zb],social:[Bb,Cb,Db],timing:[Mb,Nb,Pb,Ob]};pc.prototype.send=function(a){if(!(1>arguments.length)){var b,c;\"string\"===typeof arguments[0]?(b=arguments[0],c=[].slice.call(arguments,1)):(b=arguments[0]&&arguments[0][Va],c=arguments);b&&(c=za(qc[b]||[],c),c[Va]=b,this.b.set(c,void 0,!0),this.filters.D(this.b),this.b.data.m={},je(this.b))}};var rc=function(a){if(\"prerender\"==M.visibilityState)return!1;a();return!0};var td=/^(?:(\\w+)\\.)?(?:(\\w+):)?(\\w+)$/,sc=function(a){if(ea(a[0]))this.u=a[0];else{var b=td.exec(a[0]);null!=b&&4==b.length&&(this.c=b[1]||\"t0\",this.K=b[2]||\"\",this.C=b[3],this.a=[].slice.call(a,1),this.K||(this.A=\"create\"==this.C,this.i=\"require\"==this.C,this.g=\"provide\"==this.C,this.ba=\"remove\"==this.C),this.i&&(3<=this.a.length?(this.X=this.a[1],this.W=this.a[2]):this.a[1]&&(qa(this.a[1])?this.X=this.a[1]:this.W=this.a[1])));b=a[1];a=a[2];if(!this.C)throw\"abort\";if(this.i&&(!qa(b)||\"\"==b))throw\"abort\";\nif(this.g&&(!qa(b)||\"\"==b||!ea(a)))throw\"abort\";if(ud(this.c)||ud(this.K))throw\"abort\";if(this.g&&\"t0\"!=this.c)throw\"abort\";}};function ud(a){return 0<=a.indexOf(\".\")||0<=a.indexOf(\":\")};var Yd,Zd,$d;Yd=new ee;$d=new ee;Zd={ec:45,ecommerce:46,linkid:47};\nvar ae=function(a){function b(a){var b=(a.hostname||\"\").split(\":\")[0].toLowerCase(),c=(a.protocol||\"\").toLowerCase(),c=1*a.port||(\"http:\"==c?80:\"https:\"==c?443:\"\");a=a.pathname||\"\";D(a,\"/\")||(a=\"/\"+a);return[b,\"\"+c,a]}var c=M.createElement(\"a\");c.href=M.location.href;var d=(c.protocol||\"\").toLowerCase(),e=b(c),g=c.search||\"\",ca=d+\"//\"+e[0]+(e[1]?\":\"+e[1]:\"\");D(a,\"//\")?a=d+a:D(a,\"/\")?a=ca+a:!a||D(a,\"?\")?a=ca+e[2]+(a||g):0>a.split(\"/\")[0].indexOf(\":\")&&(a=ca+e[2].substring(0,e[2].lastIndexOf(\"/\"))+\n\"/\"+a);c.href=a;d=b(c);return{protocol:(c.protocol||\"\").toLowerCase(),host:d[0],port:d[1],path:d[2],G:c.search||\"\",url:a||\"\"}};var Z={ga:function(){Z.f=[]}};Z.ga();Z.D=function(a){var b=Z.J.apply(Z,arguments),b=Z.f.concat(b);for(Z.f=[];0<b.length&&!Z.v(b[0])&&!(b.shift(),0<Z.f.length););Z.f=Z.f.concat(b)};\nZ.J=function(a){for(var b=[],c=0;c<arguments.length;c++)try{var d=new sc(arguments[c]);if(d.g)Yd.set(d.a[0],d.a[1]);else{if(d.i){var e=d,g=e.a[0];if(!ea(Yd.get(g))&&!$d.get(g)){Zd.hasOwnProperty(g)&&J(Zd[g]);var ca=e.X;!ca&&Zd.hasOwnProperty(g)?(J(39),ca=g+\".js\"):J(43);if(ca){ca&&0<=ca.indexOf(\"/\")||(ca=(Ba||Ud()?\"https:\":\"http:\")+\"//www.google-analytics.com/plugins/ua/\"+ca);var l=ae(ca),e=void 0;var k=l.protocol,w=M.location.protocol,e=\"https:\"==k||k==w?!0:\"http:\"!=k?!1:\"http:\"==w;var Xd;if(Xd=e){var e=\nl,be=ae(M.location.href);if(e.G||0<=e.url.indexOf(\"?\")||0<=e.path.indexOf(\"://\"))Xd=!1;else if(e.host==be.host&&e.port==be.port)Xd=!0;else{var ce=\"http:\"==e.protocol?80:443;Xd=\"www.google-analytics.com\"==e.host&&(e.port||ce)==ce&&D(e.path,\"/plugins/\")?!0:!1}}Xd&&(wa(l.url),$d.set(g,!0))}}}b.push(d)}}catch(de){}return b};\nZ.v=function(a){try{if(a.u)a.u.call(O,N.j(\"t0\"));else{var b=a.c==gb?N:N.j(a.c);if(a.A)\"t0\"==a.c&&N.create.apply(N,a.a);else if(a.ba)N.remove(a.c);else if(b)if(a.i){var c;var d=a.a[0],e=a.W;b==N||b.get(V);var g=Yd.get(d);ea(g)?(b.plugins_=b.plugins_||new ee,b.plugins_.get(d)||b.plugins_.set(d,new g(b,e||{})),c=!0):c=!1;if(!c)return!0}else if(a.K){var ca=a.C,l=a.a,k=b.plugins_.get(a.K);k[ca].apply(k,l)}else b[a.C].apply(b,a.a)}}catch(w){}};var N=function(a){J(1);Z.D.apply(Z,[arguments])};N.h={};N.P=[];N.L=0;N.answer=42;var uc=[Na,W,V];N.create=function(a){var b=za(uc,[].slice.call(arguments));b[V]||(b[V]=\"t0\");var c=\"\"+b[V];if(N.h[c])return N.h[c];b=new pc(b);N.h[c]=b;N.P.push(b);return b};N.remove=function(a){for(var b=0;b<N.P.length;b++)if(N.P[b].get(V)==a){N.P.splice(b,1);N.h[a]=null;break}};N.j=function(a){return N.h[a]};N.getAll=function(){return N.P.slice(0)};\nN.N=function(){\"ga\"!=gb&&J(49);var a=O[gb];if(!a||42!=a.answer){N.L=a&&a.l;N.loaded=!0;var b=O[gb]=N;X(\"create\",b,b.create);X(\"remove\",b,b.remove);X(\"getByName\",b,b.j,5);X(\"getAll\",b,b.getAll,6);b=pc.prototype;X(\"get\",b,b.get,7);X(\"set\",b,b.set,4);X(\"send\",b,b.send);b=Ya.prototype;X(\"get\",b,b.get);X(\"set\",b,b.set);if(!Ud()&&!Ba){a:{for(var b=M.getElementsByTagName(\"script\"),c=0;c<b.length&&100>c;c++){var d=b[c].src;if(d&&0==d.indexOf(\"https://www.google-analytics.com/analytics\")){J(33);b=!0;break a}}b=\n!1}b&&(Ba=!0)}Ud()||Ba||!Ed(new Od)||(J(36),Ba=!0);(O.gaplugins=O.gaplugins||{}).Linker=Dc;b=Dc.prototype;Yd.set(\"linker\",Dc);X(\"decorate\",b,b.ca,20);X(\"autoLink\",b,b.S,25);Yd.set(\"displayfeatures\",fd);Yd.set(\"adfeatures\",fd);a=a&&a.q;ka(a)?Z.D.apply(N,a):J(50)}};N.da=function(){for(var a=N.getAll(),b=0;b<a.length;b++)a[b].get(V)};\n(function(){var a=N.N;if(!rc(a)){J(16);var b=!1,c=function(){if(!b&&rc(a)){b=!0;var d=c,e=M;e.removeEventListener?e.removeEventListener(\"visibilitychange\",d,!1):e.detachEvent&&e.detachEvent(\"onvisibilitychange\",d)}};L(M,\"visibilitychange\",c)}})();function La(a){var b=1,c=0,d;if(a)for(b=0,d=a.length-1;0<=d;d--)c=a.charCodeAt(d),b=(b<<6&268435455)+c+(c<<14),c=b&266338304,b=0!=c?b^c>>21:b;return b};})(window);\n"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 10964
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.486999982967973,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.15300000086426702,
+          "wait": 4.01800000690855,
+          "receive": 2.287999988766388,
+          "ssl": -1
+        },
+        "connection": "1043854",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.321Z",
+        "time": 118.26399998972192,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/bg_cat.png",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/bg_cat.png"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "content-length",
+              "value": "11820"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "2.229ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"2e2c-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/png"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 11820,
+            "mimeType": "image/png",
+            "text": "iVBORw0KGgoAAAANSUhEUgAAAf0AAAIYBAMAAACVgygXAAAALVBMVEUAAAAFBwj///8FBwgFBwgFBwgFBwgFBwgFBwgFBwgFBwgFBwgFBwgFBwgFBwgLjSB9AAAAD3RSTlMADQAHAgsMAQMKBQgECQbMWMMYAAAtn0lEQVR4XtzXQUsCQRiA4TkIK+HlI3bBgxD9ha1kw2DAUxHB3lIpWDqFlwUv0SEEg5aoYInEDQKhgiI6RCoUEULHjkFQ14KM/kTQIRxmkHV2kJl974rP8I0zg0Zbcs+0gjr8FwRmzkM8TQppYoT2jdM7G5gVbi9wzP2Lcz4M7CSHY+tP/vgQolIvlv6lNoRNf8Rx89fqMFSH1Tj58z4M3WE1Lv6FV+DJeMdx8CemgTd9Sn3/sw0RKnXV9qc6EC3jQWV/3oHIlbG0fv6drwem6XnbfwTN82qmdcTxLyC3f8wHZusvPebR5n28OcDs2FXQz579wuwOGtCuZbP3gHL+S+a9NsSd5qANdOmmWn6NsfVXeqHfSfQQGFmV/IkbClA6G+bzT/QKtNTxJ30OPZl2Ra1AQxE/zU9/8szQN3UMqOEfs4HIuHcRV5sdICvK76f55S7i7tmhFkB2f4rkGw9C3w9Fqf303s80UcSugWhZbn+C5K9iFLktcqAasvrpc99oiflScg+05PVrM9CX/oXEpJ1Df1lp/cTvzFSRsPaJsWpK6p9nPtnEPybTWEp/Bfpac5HQKv3H6rgr2v/L3bW+xnFleYWudrVbsplLd7Xdev0N3XTGj8QxJbISzmODChsUJUtIY4M3jw1tjMRMZhJa2LPb65k1bpzspO3N0sJ5zDIE1MTZMMOwSJgkXoYFibCbzbAMEjPJeBnmf1hb9tGq7rnPqtu3quf3yZbU1XXuPfc8H5erzlotP4rifw6Rb9SselX1Uydarchi98bXQNH8u7U7stPsbCAzpY8L8JaMgNaNxzo7r//le/rU/4lQ8K4/clFAwLeI/H4uQGlT8OqXHn2bIA/MSOzOu36sKZN9mHzzCwAyEOMnNUQ7vFSkb8Iof3kHf/f++i7RN2Qe+FteYxz2G18TPp6LbMVizNcuog9gyW8e5+s8EeBcYEdOkcxQwedEjtJ1iOSGPzDmD/URT7HMIPcnj0qy6/ABNeSJIspX7x+FN3b9iK8nTNtYE41tpv9dhyhiVJH+ZaKB+dptJ1BaY+M29rO5W8D0alB7OSdG0u7wUL/hVklkFJXoz+7e3Q7irsgixnyIQY5yp7OLQzwl0QwL/PwR/8E3tm7V4DE8YJ1kQQsK8NL12m3QUSd28ikVFQa7/3iPtphyl8Gs4mHCH7KCN4gYndpt6k2cb8g2zqpIf4GB6VwSaJrS6pAlfC4Sx2yH5wNyD5PKx/8UIkBqaXw1ZAvuhsQyxbivozwF+s9t76UvdisZVvbLQ/YwUkfM9y6YYxwskntQOKFraqaC26qBfwwOiUV8P1xLcuei4rHuKor/FxWj/Zdqv3gbRKtVbN0/7VePK8dnAsW33A5hrwy5R/+REO/dRxQe/71WrQaa3xacr1U2/b6BXOt8efjBvl6RU9N+sE6vt+8frN/6Q4ML5+cBhOO2dOi/p8qcQ6j+atDw+Db1pW0ClnTob4Z8jWsDSTzU33ndIW36H1g/f49iJwOE3EbII1/TO/8DvwC5doh8NfkHf7cOBPwI5Z3TDOwmes2QXqso0j9LGc6mrVtbYYJSF/G1ECAnDlAPAu9mYPA5iscQ0GsSTJG7GKcYCcJtg4I3CO3F5cD+V/L/Cox4w6kBkn11lInIbDOxAgH7kKP4BAofphsQwvJ8elsnVMJLwCgoIjY2YNxfQcdaJf7hEDCAdgAB7p8OiOoLGCp7WTkAHIACRAvqDYYInGHJ6w2gSooqY6W2BkgE5uuMgIRL7rv1CliCk4IFamkQfOFlVolIHtS/HHtYkcJpso0zA7D9IPuxVi8pPWCYZSm4bWCAwdj+OWTVKSuwHDOeNzwgDJBnq+oqWLXaCgDQGwwVsMwWdIEkqitfqzwBxkr/9hcQTyuJf3xW8MqWB0H3d6UyTZ4Ba3AYYCXVpl+dnb1ZRDpN6gFschhgNM30L3ActWV0KqQewCyvLqiZYvoDzg61ZdY/tpWLPNl6Nq3EwzGviHdUjmWOsZAhcIwsI/aL68Uv9vCMxR6sbzrhgIBmE9RQZiPecu0lYBqkCXIpv6YXvnEIJ1fgBrCQ6QNIuTmeQDuoKUaLXPPiSjrJz/A8NFdL/EG4o8DVr5PppH8JOSjIoFHEOd5B6qXXC4bCvXWeQevr6tEmywJK7wHYR3jMOSWLfau6SzMpygQ4l2pfd9qEkJc617cLHqcIjzl72lorgCRgGEFaEgEnUB3m/PEfE56HXgfnXy+BMooFbCpiAO4tUbsDltt5fattiunqLwGHJV3SJEaTKRh8fVniI+snefvvQkBkOMvWZvphpE3E/tqcZH+eHJb0W7phCxAZs4j97ft/eB6IHKsyYa5YBVpksv+ZhOvZ5HitIfcK9WOgmWSVP+5Jfend2n106N+MNdF7a5bvZLGjtwSnyzpwBzzxvgzNynYuHw3/uovyeXrAERM3SEr54wkIJ38mGxxXOiyOferHQDMkyfDnUyqTgX/4XbQAKJqpBhwxBfO6kDT5z38hHzUMC6Af++RzTTtB9j+Ph4HKVWSpwjrJUWOg+QTZP7ND02lfbiL1wkIQJHlMAbiYHPvnAqDof/TGBZV9/dgnwKGCKVXb7I8ni5Qe1pUWhQay5CLGQB1kWlrDt8DOH+rPSXgVxT4jCsC9iRk/02gErM4Aj68g9hkzmbCUlO2fQYMVtBag9BlK5keKgQYJub5OG2R55C5xLP70Y6D5pFzfz9FcCW0ZoB+xwW7zAiGQQrKKH8SYK/GXZAezkVtMJ0Pab916JXPkuRLQu4SPrX4SCFIrxE+G+1+O0waA31s/BppJxvjbD503MdmnHC3WCAIQjF/rlS+9uJ1XmVj5mmCH5moika+F+F0X06hmL0oSyK0nof3cIH6y3e3hE6SfBMqQJCr/Zkwkm/L16G7bXhCAi6BFLZdyyrm/dRcXxSdAu2wb5w2rSYQ+ZiQqx7m1c49i+eoRXzwrBhggShIIjn85ie3vqt6md/U9ng7QZABcN5BJwvidEfmbz7BuVHvlPXFDiDagbiQLRS/Wt9/ztfJgJ312M6wWA+C6oeUEjv8Mf9MeDzSuisLP0s+CB/a1v4P2DEU32bgmfpgcuG7w2QS0/wJvyxxZAcDpBk8HrkcUgJ597e8GsGN4pokMYz7ncWMRKyoTSHsPc7Y/16bm/LXu2UAw85i/AAs4CKo7CrNkvX/fa4hmjL90zA8ZQ200Hh5JgPFoDrh9338Etp87+nQCz/O+0BZMoJ6J5ko4ZAcHbCs/vP0fiC/VcT+qc26JAQbQV4EbBLBiW/qd4Y4+HuMFRF7fed1PUQdEtOzNGgH4tqWfzwvov8BX5M4h3izSfDQJuAfI92x3MY3yxv6+ozQeeqwhKGjTzz6RUdu2XwWFgiXkUxPLTrGCGV4jqgB80R79WZaznZGSD/iMba+4QSQpBlxXsaz859DbK49h+4Ad9J2JZAIsWxd/Duv7pjWulnDZpRr5KHUwEPrzLLP/JHPeb9lXT3vg4MFGFCdo2J74E8wpXNZLhGSYxQoLUQ5Azrb15zDYNK+bBZ1mJc1zUTRA3nbidy/sEspjFrTTHqOMx1QiNZWt2jV+1hlnsNTU37YulixFzSS4ZefXDTD7VyPM3pphMIATIYq/bLnhLYNfO49SeOo6oIkXcjWCAzhu1/W9Ip3oI8cCQwUsaMfxXNvWbw8ZP05EDuzhkMeItiofsen8A7EF1kQfIzHEtq4JOGxT/MP3ncWW/2hUVprACa2KfgDUDvHwgptYAVeMDIOB5VXHlOWq3x7yNarR9U8biW6nrhnJ3bJr/Tvo23Ix5M8CNqWr8BMt979o9fjPIhq8qAMhkDJd1JSlllNf59DrbcRpuphBrnRGj5wRy8GfKr3ZI0iJ6ztvPsUSGtZcxnLmvw7HP8Svo4ZiCfCTclrVXx5xZ1Ui/U5A/ZdqLGlKK5j3EKg/i77/pnLI4smjD+oyv+KH0ml5P6x1npfsjjuaot82K6i7cr6rcO/eFs0/jpY7U7Wr/qq0qbMMuyWsAtoUcBR6/0BHoLTten8B9bJuwGX/f1C71tWp0/JuWedA2w3+jTBbzg/yslyAipSDm3RG09fKflVsWn9dWvutC9qC5AGtLK0Bh/knJtGBp7A1DXrzfEFvm1w65WgWcjQswGG76n+NEn8ueGvC6y+vyEVYGQkZHfPHs+n8jtPVR2d5sV3AqoIKb1JMNalj/hRsWr8v0stfkV1PLrOpaBkypa4Apqx6/w5tq6yxnfUqAWDufJItAIr0qjY0gv9Fm6H/LnV0C0yhxBX/S/B5/lMy4kODV/o7VqjHG+OwF78nmnY3NcoUACWazSoa5t+sxeBHmd6oFaT7hMPOlvDOZun9rivTVLca/F+jBHOWqf2XiZD/cdlgnhaAPdUz7do1/6qMgUMexyTl1SVvYYHp1qn6hWVVmZ6za/61Qf2JFPUCoeFT4UJkD/UoeqdUdXrebukTzacB7BtFIIUKxbGItDVKSmRVbbqMVfM3RzkmDsv5GRFPu8zAfiEBSCtQ9dqPss1m9yb1/y6rHI2vABeRQ4AUPnyRcv/rhE3vl/72BpKRGD51OkZZPFNBjJYm8x/o9ahv97D0xzgrbvXECl9VqT9kzfwHescou62AeQTD8ynuqDBk5gFKsF5Rjv4etBj8naRY/SD6Gxb+OnRLI3aZtyi/uqdo1C9ZdX+WKHrbjLfsESZuQqs/CohihQ+GVurcnyrFpXXMpW6dsPEbf/dgaI8RVyujlValf9Yi/d8Ru2l5wsU8RyOAZC2hkyZHz2rbdzv8XTmGm54lalhhGACNsKQtKLu/6zbpF5tyU0QNLzIMgGZ4GSeU6Nd3/9yf1I52Oh8/8neRzP+K2ErdIgrAws2hDJ69ilatvvubO1r///7URgT6xS+5QdRQED96n6IDpNv37PwvGkagGf1cFTNpnagAr1vAOFoK9Gi6/28GeB6FpvvXFAoph6hCQbQo7Ige/U+xNqIbmf5zWEnliSp8rFpfpJ6j8EboWbK+Qwyvq0V/Q2ikZIgqVgWmBSy1Kv1SAqA5Oc4CAFMK6d9HVFGxTf8P+LLIj05/Edtx+vTDs7Tpz6vTPyKQzIVGJPrXsOuRJaq4InCtgH6D4T9XqJhPRaK/iul/yBD9jjL9iobC30q4MS30A3ToL6u8uhgTjT9r+iEqMf/xkdbFoROtC+huslN/xvRDifq/7X5g7o8hW7DkDzT98o5FDzk77q3dK3BmcOVfWWH7/5m1v843iAEGUf+Vpdvv/Z43ozFADJC0/WOe/uwreG/xsLaSnw771zz9NZFyc3dqtOfS5P+Ylf9K83jKafZ/zdOPh3ZVUhT/sEm/ewimxyYY/7JOPx7a5zXSFf+0Rj84x5X48e9lg/Fva/RDXvZguvIf1uiH2WXegOW/QN0au8ak28/8JzGe/4RKU9N9zebz3wDD+e+cKfqh5tJw/QOGTv2DPfqhD80zXP+CYbb+BfIfxubadA3XP2Fo1D9ZLP+FKMms4fo3DLP1b6bohzBJ0XT9I4bR+kfwJU0xQMF0/SuG0fpXs+X/C8QzXf+Mwat/LkWpfw6AflMqwDdc/46hXv9uv/5phlRM9z9gmOx/2DBb/zZCZg30v0hMQMX+l/GhBOoftw6Y7n/CkPQ/wbYWk2j/Gx433v+G0TXX/7ZkePSre9J0/yOGRv+j/fr3J/T6Xzek/a8YGv2v9vsfcob7nzFGFfufLbS/2+p/R4lmY/3v0P+UtvkH05JSG/n8g1GN2cfeUErnX2AUjMy/wAHAtM0/ybONIK9pdv7JCPgTaZx/g1E6bHj+jQMOcLLzj1TLTW8qzT9aBCaz4ADbmH8FKN00P/8qAAcovfPPAN4f+jD/rAfZpFTPv4NOA/Pz72D8XUrnHz4N8w+vftGf+YdLFoa/p3n+5bl+GsDOpdovOndxtXa7YX3+adLzv5xboSsbr9/p3/zbkmz+rf35b+7PA0Kh/HAK5x/v788AmJEN9uXFFudfJzn/MR9wL27F88+dPsw/1/HIzXeA5wJBpwyef78Vff59ANZD5Pn3GyYjgPIm3lNpu/9gy7wBkCGi8E3K7r+YMn/7zxoRYDZl95/sMWoAyEt4Cubuv3FN3H+zz3gEJCNJXvX1/qNFXWmehwHbxpAlQmwavv/Kj3f/lWP2/gt5BdM66/6zZUP3n+X06zkD0x7wkiR5bej+u/1G7r+DCMCkRfqTv/8Qs6tnj/+N3n+5Gvf+SxBXvi351xXef9q1fv9pxrQCyEv0n+X7b+0rgIAIMN7H+4/3wwInqwAWhOzPvf+6Hfv+66lIrkzVoAcAu8PFsybuP39fdP/5ur68BrYxBYjbY1wzcf/9v5u5/x6QhcU0BEjdYPzNeyFpT7spDtxE/09Kuz9GU9qLdo739+MGOOcj5AV6R2h7z+dd+vECfxOdQ4SwrwrPIz2mpQCKfQ6BnvTRUT3DzfmO8VyY14FHyKeobDBqKcuGQQGI20LZPD3DPqsfAHWlXzEf+RElSFHZ6Fz0eI3fzwV4h1l4MSdQHRN45sAF2HyWmTATOY+SNR0Dx1U8r2Kty2YAp0d28NKx3dQ4N9po4hLa/vEYARscNDXVF4sjGzh2B8i1QzNPa7dbd9exdan2NpVHoDET3Yp3SN+SoNNc58INONo61yMsSMh3ghgyrGfUBcZe+jjfSp5jjtQQ42SDFwxajxWx6A6Zxz5uMYZT55lr7vtEhGuSh+ljr1ELCMuWK4L43ZzQfMTwfi9/lr7H3rcx8DnQLLw9K/lyD0JaBTQC2x8RAXQVGocrkMozMNqdhWf+i2A8/57oFqu56L3LJiwAFLwVD+L6i20GEIidZz4hYVwF6mkMa2/fRWQBxbYAcqVNHfqfKAMDFAQlNEfbYAtdPeJzeawt335kSM0fQwIgngXgEM9Xpz9DCiAByE+BEM36L0BWa/tfD8DAXkUhOz9eaWdBWf45wTazzUDaIxb26Wz/+TpjcC0IgCsxw35vsfXfOqvqYBOMwHh8B/ZrWW3799eZ1fRZEr8RyoGYBMrHFtHhB0d9AdIesdBTtl6dNntwbZ4YMIGXwdFBFRpYXQO79iCWo4mINR+f87pp2jE1IKihlyXZddgEMHv2IwdRHfo1P3luN9WSiSBYm2Zlt8cK1B+CL4LBurBuUeGoCpEer5cWykDK8RMfh3eRvxPOem4XAZ+FjB4nMCACqmoB/P38djqHxE4DQi364d2hWsALfmiKfAE3+sDHomBReHZxY7XXqdNTG6vAD3Ews6tNxfljKALuHfN3+bYrWCaVNmN6mWeVtgdcyAtB+GguGDgAME/m5M9aN/4Ts9rVI60LEGtm6CSvG6/krKDo5peboRrd1fDYjc2YKlAJc8zEn7carwvAl71cWNdmwlGPtokDkCdyYG03TSJwwJsVWgCsKHn5p6iZ7qM7Z9dEEGCGyIFf9FtYgA+VyT9fL9IsVFTZG69BB80o5VCJOwcvBO+RVusxaQ+vswEyQvVCnR8TUqajyWMqx38OxT274QMwbmISJOAVP+Ryct29XCCIbvIipE36bPtyK7nkI8GzDqwrn+Osa2KfbjCSGp8yNVg9tGRijFDXtoEDt/K9Vksi/gpYIhygDsBc7KwfDtTnNqhMIMJ59Uulfl0Hb5UleOePcRawRxkJqAyhTYwkgiF87/0KXZwFxpHkcqVXvhBQ/yQERlHPv2QB21j07gl5pzPEUCncDx/rdN6ltyH3u06nc9xXu13qJG8FnobAOCUA8oE0Sg7WDu04lsI5aZCA9vF4fXeo+w6Dsy6HrcpZRD5grMmh32dk4anLZUEC2sf5EBXe1Tuh/PflowEeBQPkK9zJxGp0DPP7ApquaRkjbZqMTu0+OgHB8JhRLaiOUqG/HWIjpx7NBrRQOYdQB9MFzEcar6nQvxXWI2towJxlgHKT4yPYOTC5EN5SoH8qvN0ZAiowOYz8K1HAGPSRgsmNgIKqrAxHljL528hDsQ0ITUgwC0FvgctVYLh/1JpkqMT3QuIMAM3jYngNCHrzxiXixFqb4d05lMJz6skyAMC99Y9EhDMQ9OZuP24PqLJqPKpU0GOJUq3J4QS6Y2z++OUd9oeg9+7tLx/x700M4U2KXGPFCBYphZcn8cIA5udn3FuF+XsjNPxdjdXFnaD3AgFce0DE6xvsYXHnWH1eI3QpeRVJgPRgeJdog6D3BvYrnUNMBsgyM3xVaqGGSfISQJ6+8UB2n2bVA7tVFgNkmKO+snT+aSO1DDAcdv3cOjZ3kUE8R8v6K5ykwKeoe+er9FCOZwKuU1MyuyjDjE35gJnin6GC726APpo4cFtVcUd2s4vIphnHeJmZ4MnTHuMCSo4nChxZhtOZwXIey4pJWtc1eTmbMR8YAD01cWAztwkvCkzNy/X6lPyY5eZsyl2KAUZTRH6ekUJbxqcfb+scJQAn+Xf7ln7ZAAZIgRGE9TR9ALLwb9GCTVBnotQQnCzv4xZ4xVBUlQ58HyfRZBF7YIBVqtNxXeHhaRKBHB+/3HRAxjWFJ+YsZQEdFDIXIHYs3MJEJYmlhoqPXF6ZuBOIUtXJ4w2Ny5DwZbJN+ZyZ/fU0nwAniHT5ulun0wRZrlo7L3h64qhKJipI+npGcbgH4ykeB5QTt4KeULsNBiODqlqrfH3xJo/JXrNKrM7ZlNZsBjQLLwgEpvMJ4QfS7QP7shiyprcpWkDmhGf6cXbQsZSoEvxW+SZojAzygapiw/7pRzt1URzVPqaJBCX5KDpPc9gDa2xlQjgvzwQp2E1dOtxT1KIfwmP2kRfKPnm1QhZ1dq4puPZSGZi87Cv8GtTVAeH6IRWRUdhQwsDNJMjvicYInVAZXRugM9KTS4A2++oJ23APiQ+9in26jEzEBaQTENrp0ILfim/Ay6mI8j3ojyC6s6Jrb3tdu+S/L7kEKa/Ss5jBNtKiNLxdJaIFSJ58Mq58d4+DhaRTRzFz5DclvwDvy0xe6HpWGu4zyookV7QnOHp/sCX6viFEzP4Q3igrNT1MMPtgfK7Q4KH0cFKSH3u8e+HfKgIQ2dQis3Yv4eOmdb2PMQuUKdA/HHKSqAzPX0WY4Hyt/0avzONt7rq7b1Lthq8K+3Ktd0Sf0RjBYXh2nhBw5B9Sa9lmznapCtnZJRzgwQHm8R9EhiKiX/WCA5wfJ//Nt5otS0GoXZFiRYv+LeafTePzLDeAUDurcTwTEDl8Kf1YmRf4JJ7GtKwRGcof9kPt/QtRwNgQol+uACdwx5VgpNI5IsdvzLIAFK7JUdSjfy/HTDwvaDfJEjFg2UzC+YaoYUWdfqGb8CPCazfJAR9KcHLVZtEzwNejf4SbI/4gvJ3Xj7da/onWZRg1qILfxj8EMO1KFWOadxc7KAKArOwY8H5pYAWe/ISooxg+pAXlKz7NLwCsgA3qcbpnryL9AT/c83/Mne1rHGUQwFd6epe7a0nQ3ebOph/8C+6I2lqJbBCPfBBJSECqNqQ0UG1BVkQRo3BHwJxY5BY1uCiyxZoWROiBGPCDXOiX+kEwXxT8IBVR/DO8u9zN9WZnd2bzZF/mU8jb7e95mWdmnp0ZxQGAwgZbhz/yNuUrH21k5P8y0bxWQK6mulw4ax2G/p25pdDLDSl2XXh73vJNJD8a0T+5odAgUS5lfLAJ+dcYq0NNIGFRPPN/h4cHDtS7WuQATPpvQShVriRQsNdi2e+gTE6ZYD2eE/aubgC/n+SeOhp4qFU426Q1Yra5OeuojbZJH2w8P1MTcXtMod+YVx6FktPPXW32ZLP7xZzjTKlLSd67GvMzkutOTU+6kwfGRfqk7IlsrCny05JPKf+avHc15n+MEVxRKZVy2wN2OhJ+rZ1O/o4nSjETDX8jlfiGN0phRMCfWgX4KBHZ6ETAnxoFWAp42acoS1SshuD/5ayZLgX4Ym2Mf5K4plgT8S+K+O2u7XOrPwQLS2nA162sjZ1/bACcEmWNtiT8mamUyTqqWHwPeTaSRFVbzn8sbereRCeRSXWatCQdzisS/rfTZu3itF90RvE5OqAl7kn4r6eM30WauESeUYuSmqR1CX+AztOTmH6c/PQwObVlyf2HyfIHqr+rZjUBYx+bYqdJ1V4SVMc3NAF/wf+yz9IKiRl7o2mZphN86vz9Z4nnP/hVfc4eRLLOAcDLN2GwE/H1qogfK8CW6P6b5987+MVss9ncGgEvDwK7hQSmH22Ak2Eb98DgnZLwt8fDCfNoGtqxTz+uSjTpk9/BX/+clPAjC7OALtwKibl6e9j9QTujwl5/tgT8RXRPmsMP0k4q0nOMrsgABts6e/xVBPwFbEzayOgsJDP98CQAiulK7PufpoD/QRxNauCZqMY9/bj2ieFiBcCZwNdBQ7D881iVTuBTJx+36Yc1ILaA+LYF0GGH5/8LnzA5tLpidBBcv1fSd8miODqfAMXz73t8CRuvrmJMUaErBAeZi1kktgttIfH8Fz0nScNTYKAWn9+P9zEMDTVFZS4BkufPUPWRcYg9E0tYbIVq3oHqcqEJ6QQlwBqagD/vjaVkvP/8rViifkH1j4wOOgEDNOBx8Jt5/t5/0nn12o777IOkBboig422DLVrLkv4J7DVQeeKnYgQPDA1cYNOx66hBUBtmoqE/yH46GD1+kF05MHtAHfIkhR59GfE9BmWhP8NKpvAhg0UmwpcEZSBeYnYkGVqy8BPeP4GlUxdI+yRjWgNfyvAlwFZtbzRgV2/ioEtEf8e9ZbECTS4kVuBhssVg8BZCxAf1k2f9WKK+KswUpTn5ca0A1akKdEzLl6jODy8A99W4K9R/uhGEqsfZwYa33vio6+QRbMWZfw2GUgpkhOzEwE648gSnXSWO3g/fkk0ejVMFX6tSuX/Z+xo8HUGH7W6MP40kVu+anqaiUxrSvzHRwX3UIZQ5G4/PwBT+k/muELW+29i557ArjTP3xvYeqDdWdeijgQtauIBAPniP2u8Br7jbKNkaRE/ukkhPB79ZtSBoLoWagCAeJ9xJlT47x/cr+rQry0CgUgTrwR5gelX48cxjwuzd689Hc35L2+/m/lBzO+q82eWYg768pKVHsCvagr88cU8wE+TyoRwQ5nq/NDGOW7HX53fqGhy/ovAz5chS+T0w3FdnaGHqmVy+8eVVeFL8vQbJX9Ov8eowc8BQG7/LfRyNZp1wvGKVKQdzBc+7j7era0DfqZWxhUtNP/54UJ/7ZwZuwq4zPdVHOLq+wPDPnvHdwRWrXD8iND4wwquSTP4YEPZFhqu4k7I3nCTgwzSbUyOm2BK/X8kM25QSabXh47RrloSrfF4dfBxYcvCQLDq+bklLilZzn/ecZzh1J7xf4JL1jDuVEYjE070M3lm+UPbfHg825sLtNDvkAh5mGjpi+N/+t1hbuo2MQCZUV+y3uZoQHjt58Nb/C6Y17d5/OUBWGaTbGXT7AuaeTF/Y/wW5QWbikZe6yfJPVO/P/C6DtGG0HLVHIUvO/8Td74vbhRhHF/J1o2718NwJtqk9YV/QYI/rlaFhNLQGBGXFk8qiEsP6umbyJHDHz1pELVaChe0Vq1KglYtUmig1QoiLbUqiOBRxTciFrUI4v/gJZPka56dnZ0lO7PMy9zt7ueZZ2aeeZ5n5hHg10hR2BvAL2hR+RkLBnxIBYgUwnW4sypS29eAcZ0LuQI7d576/M/Ey++MWKB0wlsC4XdciFK5k07Rbni9KWudDMUU/Hrx8RttxkKuSOmE3xO6RXhvl/geMUe498X+a54EIPAPsfE3/avQXUKX3EXsW7FAS3c+CSevCcsfvOH3SXfi5jc9sODVgvdsQrIa5kyZBj+tI2H8N6lpXMVmMUZ+9lzyqlXRDTt2huZkWN9LDYJHv8VEFu76cklsF/0UKz9fr3oir0QbGRvERhDSf+irvCOScorG9puQV7z8Rtf/JZtFkm7xwnbWiz+Lxv2VV4hvPayKQYXN9OSfFhTw89YVyxV2DT9p4Zl/AiopnNje4HpWgchTsjynaH1DAT8bjkTbKoKNieUG+q7Sl+6elEHubd/VILMyrq800Q18owL+TWwwE3GXZW5KPh7iNMqWeWZN+OrnkL62sVrEz2+5Pj+cKQrKpgSJCzNeSE7nN1Ke36fJitRFnDB+fqPqN0XXRRuNNvE1c3uXX1C0Jhf4uIgfYXQXFfDTtRUCv1GuKGehTFIEhHVk6qAX2nIlqCPpIAX8PPWqiHrH9AIEcDLk/vS6bNJPG52NAaqO3/b1x3VBCyD6AwFi+OqETjnrFJWMJH8TE7QCfiwv0vw1sqn7uk9PnLISv+fm5fjb+DpF/A7MEQl+qDHWeWL7iH+HAEL58XEq+WFegl+EP30rLHsQgJi/hFNwCvj5Q6wVXGLnaBz4G3zLXnCJnR7MP0xOqvgxpeOlVzOPi5yyW751p895WnYDBVDC642L2KCr4zcqk0usC1nw8A9NkQ2J0WwHCADLL4wTlfzQsiIMro4If9psyONIauLWI7geXVHFyFTFj0NDebL/oO0kw58yQQbabLchALLFKJOZWTW/8/8tVgvyJ/gw+FLRmPm7wjRfAOZ4LmpiuCjix5YHVoaL8efHh6N8yus8IYB9/gVgK7HMFPND0qxriyJ8OMqjN1pWL92DACb8Xw1oZUcHv+WNR1qXM+FYd7LYHUkPiN4oqskTQIp9CWYl9fyYaW34Q0l1ov2NyDmZtOEREADn0W4mO16VzujhT49e1oX6+/GnFAAw0UzOw6sDBaggOqWWH26AQt9DWZDAhwCi44c/3uyrookhqZofK9rHPfgaJjR0D/DJ9CXdkJ5EBYC5FZ3xxApsH9X8WGyyeKVghiLKK9d+FdR+gwBgkLpY/HTwW1cR2hXhyxdvEmdniVfXl7FcauFHKZo5aXxUURc3unQKbWuagb6nrIX/ND+slW6HF4Az/w3v/O2hAKeIAFZRdEc9/8xnxGVPDXRxO3guhpox2FzSWMljZcX8dbi0H5HEl69okrsCpnABwC1s9UjpLXX8XazQE+EsCXzIin9EZule+c47AgGQE4drKvmR1YFFHv6J8xLsyMicHPXv7YhWJqYOAUD9YASoG/8lWhiP+qfkZfDaRrb6F68joz66AHLz9NDTgur5z0FGhw9fa9s56Re3StiWq+Q3enSn+RzwtbbJwIAFG1AdP4K6HfIZMNm0NQQG8FmH1PJD0Hl/L+hvL0Dz8FVK+VEivZM4PmYeaKUOftODqHcmio/AAOv+gj7/F5N1HXH9JBoCA01d/i9kGOepEaK/wfLx0P26/F+ZIvCTF4A2/xeM4Gzi+PCsafZ/dcmtF8k200X36+F3ksbnuGNzDU38yMzPJo+P3f+ioZF/MzITE2+7kCmhjd9yxRdSmYdvZ0exY+DbfWnjUTsOB70q7aHQjSZ+pLbu5ddLPDaeH7+acog8gGqYJ/ie0RJUURc/FCB3wU9PKoa+P4ViHjwX6ht+FnlSWvhhBPNHwIOuIJwRsZ32xwYu8LU/U9TNb3rcEfDDOJETJ8Vx8VqUhoDZ0sajjvGFaZVwxk4rPy7dLvorRi+NnJnmZaQyRGpImhgfV989PMd/lneK5Ix+fhtJSpNp/dv+nEgVeBixgijNIuVrcJ3FWc4ha0MnP4xgRAGR6PQlMZTWBuGqn6LyX+tjrZP0KnMQ/Z33Rf4WkuBP0UDQKscZUMnkjToOMUi32sC6dn2KfYQtOhj82Pno5IcRjA6Z8TgbglRfN+tYKCQanmVzTpft9MbPuoxCeInwO5MnVEq8DYHl9S2TWlQd7Q6etYk3rz/PFh32UA+mr15+nLfY5rJuX2VnmGgrDcCvYZ6UaQ5Tqi43u7LGIu/LfaWC0183P4zgPwb5GBbO4ZO/mRvOVAfk+XvsagmXmDXIQM4Pbh3LHoXpq5sfRvAtfUXcvysg995mG3MnyixlM22Z5e7pmTA/cfvqhliUdn6EAnLljwK3IOjEboTQdIvNFiuQKHfz9fksXqufH0bwolUSDMMWG8S2/NkMy2O6UsocENlGb43yEJPjN6pMAQa2ajnoMsICG7XkL4RFCReYGIqCsoX7kIeaHP/M0PxKtwP1MD3kdqQHQIutaKngGWNlkARaRdJrUvxGd2h/zXBOAsAEDrsrgc4YWxlkPvgv5hoGkl4T5LeZAuAkjL9VhtwVQSUyolM/Mrk9FGgeZMtIQ0+U3yiNvqId9Lkpxo27EsKHfxlHq/hKt2ig+5Pld0YK0AyaiS2PlQgyJb00FfYgJ2BXyyQznnoT5Ucu9GA4dsSH9NdljqaPrd4K36XL7ILx0vtfd+fz2lQQxPGFvJg0WvFRozYaKf4FlvUHtVjiwaCe8lDwFwiBgooeIiVSpUqKFZ4SiqGgBilE/HFOUPHioQURxUtLRaknBRX/DE2z3xi7b8wEha47pxySw+flzXd3Z2Zntv0T6/sL/jAUYJZSwLybUGAbeZvfDGSTUr9biD+mVp4/4ikFCFEKGFNv8gXOAoANY9R1C6T6QfwTYuX5RR5x0HmlRgSRCPN2gA3d61KqSagfajAM4HdwCCcVcLyxke3i8heWfrOJVL8Z1T6mRxjAD1ccrkuSHgAAeKf8Jcr9024PYo9VI/jxAlTELOHg0cY6xedXu2ZCbuZECEF/E/jhjFvrCpgiJL3aGb8KfRHqp2LjVUP4kQuqQgGJa/qreKGKrFvBJiAw+DMs9uPvN4MfChDPaQroFKWclvKGm1QHAYaV6n7tuU9vysHyE/laO03OqJzfdmP4kQ0eXqaAYwOt7ev1XlH0djHW2hOwsEz9+pHxNYYfEalPWLWQrGnNAmuSTvf0ijwKaLYO9VMZ74pJ/EqRklehgAGDeE5pveKoodzJWsCVOKjfWBY5D4P4kQw7X4MCjmRd3XK84L9uvQWo35l+ZF2N4kebk2dKAUPZYAqGHaJntURddyfu3pnFj1zshoYuRz2io/vUkJ+i0aNFuZglWqHktGGGRvDrtzC3tJuAFi9PySH/p02IqO+nIvWPRSkXy+1mP0Y8KGLBNH60oMBJCHZ2QUqJGq7OrHfZTyuiW2snagK/Xo3gZFsb2tXtWqljevRBnnzf7KPdD18QJvKLEQWQTOvXkWNLBM7k4J9f8vi09EfxhsPeKkl4gS8VzONH/QvZ8dNrzpodLcq9epu/clkqaezWkpqX4QQotzCRHwUpsGRKT5RUfxN7v2kprbAsQ4/YOiYM5ceyF1gbHmZPJagFJHVHWhdCc/lFyKXmTce43fmcwIK2Vy0bIVP5UZQTTOox7yiE4P7a4oJSI5P5oYEVPWzLLNO9GNzDNw/tM5xffCNqUsKcKWbYOlaIGNM7YTY/WhRViUxxglH8QdSzptFgwnB+4dSCY5ceq1B3LfWYnCxWPsP5hTNfJUolGMVKYbKFd/qEMJwf5jDJOntKTs5Efr7FiEkufC/5v/mFx5hMswbubxs/BKDAGN2bsZM/zOhPNA73t5A/xjgCleD+tvFDADa3P/wkrOSHAKTaxv4zVvJDAE7umaAvDZfg/lbyN7Oax6fkd7/lMfj+A4nBtXB/u/ghAAxL2Mt/n8OfsZc/zOGv2MsfY+DHhY38fAFIWMzPmAUen7OTH+bLMs1+D3sDO/lhByblAJZ7DK5fkMgCGcdvv/X9AMxFumDADjNpAAAAAElFTkSuQmCC",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 12406
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 2.52799998270348,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.47699999413453,
+          "wait": 113.96099999546999,
+          "receive": 1.2980000174139263,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.321Z",
+        "time": 235.42299997643568,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/logos/logoBig2.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/logos/logoBig2.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "2.576ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"61c7-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "text/plain"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 25031,
+            "mimeType": "blah",
+            "text": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI5MC40ODgiIGhlaWdodD0iMTkuNTQzIiB2aWV3Qm94PSIwIDAgOTAuNDg4IDE5LjU0MyI+PGcgZmlsbD0iI0ZGRiI+PHBhdGggZD0iTTgzLjgyOCAxOC40MTdjMCAuMzI3LS4wOS41OTUtLjI3LjgtLjE4My4yMDgtLjQwOC4zMTItLjY4LjMxMi0uMTE1IDAtLjIxNy0uMDItLjMwNS0uMDQtLjA4OC0uMDMtLjE3LS4wNi0uMjUtLjExbC0uMDI4LjFoLS42NDJWMTYuNmguNjd2MS4wMmMuMTAzLS4wOC4yMDctLjE0Ny4zMTQtLjE5OC4xMDYtLjA1LjIzLS4wNzYuMzctLjA3Ni4yNjMgMCAuNDY1LjA5Ni42MDcuMjg1LjE0Mi4xOS4yMTQuNDUuMjE0Ljc5em0tLjY5LjAxM2MwLS4xODYtLjAzLS4zMjgtLjA5NC0uNDI4LS4wNjItLjEtLjE3NS0uMTUtLjMzNy0uMTUtLjA2MiAwLS4xMjguMDEtLjE5NC4wM3MtLjEzLjA0NS0uMTkuMDh2MS4wNDZjLjA0OC4wMTguMDk0LjAzLjEzNy4wMzVzLjA5NS4wMS4xNTUuMDFjLjE3NyAwIC4zMS0uMDUzLjM5NS0uMTU2LjA4Ni0uMTAzLjEzLS4yNi4xMy0uNDY3em0zLjIyNC4xNGgtMS41MjhjLjAxLjE2Mi4wNzIuMjg3LjE4Ny4zNzMuMTIuMDg3LjI5LjEzLjUxLjEzLjE0IDAgLjI4LS4wMjUuNDEtLjA3Ni4xMy0uMDUuMjQtLjEwNC4zMS0uMTYzaC4wOHYuNTM2Yy0uMTUuMDYtLjI5LjEwNC0uNDIuMTMyLS4xMy4wMjctLjI4LjA0LS40NC4wNC0uNDIgMC0uNzQtLjA5My0uOTYtLjI4cy0uMzMtLjQ1Ny0uMzMtLjgwNGMwLS4zNDUuMTEtLjYxNy4zMi0uODE3LjIxLS4yLjUtLjMuODctLjMuMzQgMCAuNi4wOS43Ny4yNnMuMjYuNDIuMjYuNzR2LjI0em0tLjY2NC0uMzkzYy0uMDA0LS4xNC0uMDM4LS4yNDUtLjEwNC0uMzE1LS4wNjUtLjA3LS4xNjgtLjEwNi0uMzA3LS4xMDYtLjEyOCAwLS4yMzQuMDM0LS4zMTcuMS0uMDgyLjA2Ny0uMTMuMTc1LS4xNC4zMjJoLjg2OHptMi40NjggMS4yOWMtLjA3LjAyLS4xNDcuMDM0LS4yMjguMDQ1LS4wOC4wMS0uMTguMDE2LS4yOTYuMDE2LS4yNiAwLS40NTMtLjA1My0uNTgtLjE1OC0uMTI2LS4xMDQtLjE5LS4yODUtLjE5LS41NHYtLjk3NEg4Ni42di0uNDUzaC4yNzN2LS41OTZoLjY3di41OTZoLjYyM3YuNDUzaC0uNjIzdi43NGMwIC4wNzIgMCAuMTM2LjAwMi4xOSAwIC4wNTUuMDEuMTA0LjAzLjE0N3MuMDQ3LjA3Ny4wOS4xMDMuMTA4LjAzOC4xOTIuMDM4Yy4wMzQgMCAuMDgtLjAwNy4xMzYtLjAyMi4wNTctLjAxNS4wOTYtLjAyOC4xMTctLjA0aC4wNTZ2LjQ1NnptMS42Ni0uMmwtLjEzNC4xYy0uMDUzLjAzNi0uMTA0LjA2Ni0uMTUuMDktLjA2NS4wMy0uMTMzLjA1LS4yMDQuMDY0LS4wNy4wMi0uMTQ3LjAzLS4yMy4wMy0uMiAwLS4zNjUtLjA2LS40OTgtLjE4LS4xMzQtLjEyLS4yLS4yOC0uMi0uNDcgMC0uMTUuMDMzLS4yNy4xMDItLjM3LjA2OC0uMDkuMTY0LS4xNy4yOS0uMjMuMTIzLS4wNS4yNzYtLjA5LjQ2LS4xMi4xODMtLjAyLjM3Mi0uMDQuNTctLjA1di0uMDFjMC0uMTEtLjA0OC0uMTktLjE0My0uMjMtLjEtLjA0LS4yNC0uMDYtLjQyLS4wNi0uMTEgMC0uMjMuMDItLjM2LjA2cy0uMjIuMDctLjI3LjA5aC0uMDZ2LS41Yy4wNy0uMDIuMTgtLjA0LjM0LS4wNy4xNi0uMDIuMzItLjAzLjQ4LS4wMy4zOCAwIC42NS4wNi44Mi4xN3MuMjUuMy4yNS41NXYxLjQyaC0uNjd2LS4yMnptMC0uMzI1di0uNDMzYy0uMDkgMC0uMTg4LjAxLS4yOTMuMDMtLjEwNS4wMS0uMTg2LjAyLS4yNC4wNC0uMDY2LjAyLS4xMTcuMDUtLjE1Mi4wOXMtLjA1LjA5LS4wNS4xNmMwIC4wNC4wMS4wOC4wMS4xLjAxLjAyLjAzLjA1LjA2LjA3cy4wNi4wNC4xMS4wNWMuMDQuMDEuMS4wMi4xOS4wMi4wNyAwIC4xNC0uMDIuMjEtLjA0LjA3LS4wMy4xMy0uMDcuMTgtLjExem0tNjkuNTEtNi41MjJjLjE0My4wOC4zMDMuMTYuNDguMjM1cy4zNy4xNC41NzMuMTljLjIuMDUuNDEuMDc2LjYyLjA3Ni4xMyAwIC4yNy0uMDEuNDEtLjAzLjE0LS4wMi4yNi0uMDYuMzctLjEycy4xOS0uMTQuMjYtLjI0Yy4wNy0uMS4xLS4yMy4xLS4zOSAwLS4yOS0uMTItLjUtLjM1LS42My0uMjMtLjEyLS41Ny0uMjMtMS4wMy0uMzMtLjMtLjA2LS41OC0uMTQtLjg2LS4yNC0uMjgtLjEtLjUyLS4yMy0uNzMtLjQtLjIyLS4xNy0uMzktLjM4LS41MS0uNjMtLjEzLS4yNS0uMi0uNTYtLjItLjkzcy4wOC0uNjkuMjQtLjk2LjM4LS41MS42NS0uN2MuMjctLjE5LjU4LS4zNC45NC0uNDMuMzUtLjEuNzItLjE0IDEuMTEtLjE0LjQxIDAgLjc3LjAzIDEuMDkuMDkuMzIuMDYuNi4xNC44My4yNS40NS4xOC42OC40Mi43LjcyIDAgLjE1LS4wNS4zMy0uMTQuNTRzLS4yLjQtLjMxLjU5Yy0uMTEtLjA4LS4yMy0uMTYtLjM4LS4yNS0uMTUtLjA4LS4zMi0uMTctLjUtLjI0LS4xOC0uMDgtLjM4LS4xNC0uNTctLjE5cy0uNC0uMDctLjYtLjA3Yy0uMTIgMC0uMjMuMDEtLjM1LjAycy0uMjQuMDUtLjMzLjA5Yy0uMS4wNS0uMTguMTItLjI1LjItLjA3LjA5LS4xLjItLjEuMzUgMCAuMzUuMzcuNiAxLjExLjc3LjMuMDYuNi4xNC45LjI0LjMuMS41Ny4yMy44MS40MXMuNDMuMzkuNTguNjVjLjE0LjI2LjIyLjU5LjIyLjk5IDAgLjQxLS4wOC43Ny0uMjQgMS4wOC0uMTYuMzItLjM4LjU4LS42NS44cy0uNi4zOC0uOTcuNDljLS4zNy4xMS0uNzguMTctMS4yMS4xNy0uNDUgMC0uODMtLjAzLTEuMTQtLjFzLS41Ny0uMTQtLjc3LS4yNGMtLjE0LS4wNi0uMy0uMTUtLjQ2LS4yNy0uMTctLjEyLS4yNi0uMjgtLjI2LS40OCAwLS4xNy4wNS0uMzUuMTUtLjU0LjEtLjE4LjIyLS4zOC4zNS0uNTguMDkuMDguMi4xNy4zNC4yNnptNi40OTctOC4xNDVjLjU5NSAwIDEuMDc4LjQ4MyAxLjA3OCAxLjA3OHMtLjQ4IDEuMDc3LTEuMDcgMS4wNzctMS4wNy0uNDgyLTEuMDctMS4wNzdjMC0uNTk2LjQ4LTEuMDc4IDEuMDgtMS4wNzh6bS0uOTc2IDIuNjU0Yy4wMy0uMDEuMTE0LS4wMy4yNTItLjA0LjEzLS4wMi4yOC0uMDMuNDUtLjAzcy4zMi4wMS40OC4wNGMuMTYuMDMuMzEuMDkuNDQuMTdzLjI0LjIxLjMyLjM2LjEyLjM2LjEyLjYydjYuMTZjLS4wNC4wMi0uMTMuMDQtLjI4LjA1LS4xNC4wMS0uMy4wMS0uNDYuMDEtLjIxIDAtLjM5LS4wMi0uNTUtLjA2LS4xNy0uMDQtLjMtLjEtLjQyLS4ycy0uMjEtLjIzLS4yOC0uMzljLS4wNy0uMTYtLjEtLjM3LS4xLS42MlY2Ljl6bTMuMDUtMi4yOGwuMjMtLjAzLjIzLS4wM2MuMDgtLjAxLjE2Mi0uMDEuMjQzLS4wMS4xNjMgMCAuMzI1LjAxLjQ4OC4wNHMuMzEuMDkuNDQyLjE4LjI0LjIxLjMyLjM3LjEyMi4zNi4xMjIuNjF2MS4wN2gyLjEzNXYxLjU2aC0yLjEzNXYzLjI3YzAgLjcxLjI5IDEuMDYuODcgMS4wNi4xNCAwIC4yNzYtLjAyLjQwMy0uMDdzLjI0Mi0uMS4zNDMtLjE1Yy4xMDItLjA2LjE5LS4xMi4yNjctLjE4LjA3Ni0uMDYuMTMtLjExLjE2LS4xNC4xNTIuMjIuMjcuNDIuMzUuNTguMDgyLjE2LjEyMy4zMS4xMjMuNDYgMCAuMTMtLjA1My4yNi0uMTYuMzlzLS4yNTcuMjQtLjQ1LjM1Yy0uMTkzLjEtLjQyNy4xOS0uNy4yNi0uMjc1LjA2LS41NzUuMDktLjkuMDktLjYzMiAwLTEuMTIyLS4xMi0xLjQ3My0uMzdzLS41OTctLjU2LS43NC0uOTZjLS4wNy0uMjEtLjExNy0uNDItLjEzNy0uNjQtLjAyLS4yMy0uMDMtLjQ1LS4wMy0uNjdWNC42NXptNi44OTQgNi4yNGMuMDUuNTYuMjIgMS4wMi41MiAxLjM5LjMxLjM3Ljc5LjU1IDEuNDUuNTUuMjYgMCAuNDgtLjAzLjY3LS4wOXMuMzctLjEzLjUyLS4yMWMuMTYtLjA4LjI5LS4xNy40LS4yN2wuMzEtLjI3Yy4xMy4xNS4yNS4zNC4zOC41OHMuMi40My4yLjU4YzAgLjIyLS4xMi40Mi0uMzguNjEtLjIxLjE2LS41MS4zLS45MS40Mi0uMzkuMTEtLjg1LjE3LTEuMzguMTctLjQ3IDAtLjk0LS4wNi0xLjQxLS4xOC0uNDYtLjEyLS44Ny0uMzQtMS4yMy0uNjRzLS42NS0uNzItLjg3LTEuMjNjLS4yMi0uNTItLjMzLTEuMTctLjMzLTEuOTUgMC0uNjQuMS0xLjE5LjMtMS42NXMuNDYtLjg1Ljc5LTEuMTVjLjMzLS4zMS43MS0uNTMgMS4xMi0uNjdzLjg1LS4yMiAxLjI4LS4yMmMuNTcgMCAxLjA2LjA5IDEuNDUuMjYuNC4xOC43Mi40Mi45Ny43MnMuNDMuNjQuNTQgMS4wM2MuMTIuMzguMTcuNzkuMTcgMS4yMnYuMjFzMCAuMTctLjAxLjI2bC0uMDEuMjZzLS4wMS4xNS0uMDIuMmgtNC41em0yLjY2LTEuMTVjMC0uNDktLjA5LS44OS0uMjgtMS4xOXMtLjUyLS40Ni0xLjAxLS40NmMtLjQxIDAtLjc1LjE0LTEgLjQzcy0uMzcuNjktLjM3IDEuMjFoMi42N3ptMy4zNyAyLjY3Yy4xNC4wOC4zLjE2LjQ4LjIzcy4zNy4xNC41Ny4xOWMuMjEuMDUuNDEuMDcuNjMuMDcuMTMgMCAuMjctLjAxLjQxLS4wMy4xNS0uMDIuMjctLjA2LjM4LS4xMi4xMS0uMDYuMi0uMTUuMjctLjI1cy4xMS0uMjMuMTEtLjRjMC0uMy0uMTEtLjUxLS4zNC0uNjMtLjIzLS4xMy0uNTctLjI0LTEuMDMtLjMzLS4yOS0uMDYtLjU4LS4xNC0uODUtLjI1LS4yNy0uMS0uNTItLjI0LS43My0uNDEtLjIxLS4xNy0uMzgtLjM4LS41MS0uNjMtLjEyLS4yNi0uMTktLjU3LS4xOS0uOTNzLjA4LS42OS4yNS0uOTZjLjE3LS4yOC4zOC0uNTEuNjUtLjcuMjctLjIuNTgtLjM0Ljk0LS40NHMuNzMtLjE1IDEuMTItLjE1Yy40MSAwIC43Ny4wMyAxLjA5LjA5LjMyLjA2LjYuMTQuODMuMjQuNDUuMTguNjguNDIuNy43MSAwIC4xNS0uMDUuMzMtLjE0LjU0cy0uMi40LS4zMS41OGMtLjEtLjA4LS4yMy0uMTctLjM3LS4yNS0uMTUtLjA5LS4zMS0uMTctLjQ5LS4yNS0uMTgtLjA4LS4zNy0uMTQtLjU3LS4xOS0uMi0uMDUtLjQtLjA4LS42LS4wOC0uMTEgMC0uMjMuMDEtLjM1LjAycy0uMjMuMDQtLjMzLjA5Yy0uMDkuMDQtLjE3LjExLS4yNC4yLS4wNy4wOC0uMS4yLS4xLjM0IDAgLjM1LjM3LjYgMS4xMS43Ni4zMS4wNi42MS4xNC45MS4yNC4zLjA5LjU3LjIzLjgxLjRzLjQzLjM5LjU4LjY1LjIyLjYuMjIuOTljMCAuNDEtLjA4Ljc3LS4yNCAxLjA5LS4xNS4zMi0uMzcuNTgtLjY1LjhzLS41OS4zNy0uOTYuNDljLS4zNy4xMS0uNzcuMTctMS4yMS4xNy0uNDUgMC0uODItLjA0LTEuMTMtLjFzLS41Ny0uMTUtLjc3LS4yNGMtLjE0LS4wNi0uMy0uMTUtLjQ3LS4yNy0uMTctLjEyLS4yNS0uMjgtLjI1LS40OCAwLS4xOC4wNS0uMzYuMTUtLjU0OC4xLS4xOC4yMi0uMzguMzUtLjU4LjA5LjA4LjIuMTcuMzMuMjZ6bTUuNTUtNS40OWMuMDUtLjAxLjExLS4wMi4xOC0uMDMuMDYtLjAxLjE0LS4wMi4yMi0uMDMuMDgtLjAxLjE4LS4wMS4yOS0uMDEuMzQgMCAuNjIuMDUuODYuMTZzLjM4LjMuNDQuNTZjLjE2LS4yLjQyLS4zOS43Ni0uNTlzLjc5LS4zIDEuMzEtLjNjLjM4IDAgLjc0LjA2IDEuMDguMTlzLjY1LjMzLjkxLjYyLjQ4LjY2LjYzIDEuMTJjLjE2LjQ3LjI0IDEuMDQuMjQgMS43MiAwIC43OS0uMDkgMS40NS0uMjcgMS45Ni0uMTguNTEtLjQyLjkyLS43MSAxLjIycy0uNjEuNTEtLjk3LjYzYy0uMzUuMTItLjcxLjE4LTEuMDYuMTgtLjMgMC0uNTUtLjAzLS43Ny0uMS0uMjItLjA3LS40LS4xNC0uNTYtLjIyLS4xNS0uMDgtLjI3LS4xNi0uMzUtLjI1LS4wOC0uMDgtLjEzLS4xNC0uMTUtLjE3djIuMzFoLTIuMDZ2LTl6bTIuMDggNS4zNWMuMDguMDguMjMuMTcuNDQuMjkuMjEuMTEuNDUuMTYuNzMuMTYuNTIgMCAuOS0uMjEgMS4xNS0uNjFzLjM3LS45OC4zNy0xLjcxYzAtLjMxLS4wMi0uNTktLjA3LS44NnMtLjE0LS41LS4yNS0uNjktLjI3LS4zNS0uNDctLjQ1Yy0uMi0uMTEtLjQ0LS4xNi0uNzItLjE2LS40MiAwLS43Mi4wOC0uODkuMjQtLjE3LjE2LS4yNS4zNC0uMjUuNTN2My4yM3ptNy42Ni0xLjM5Yy4wNC41Ni4yMiAxLjAyLjUyIDEuMzkuMzEuMzcuNzkuNTUgMS40NS41NS4yNiAwIC40OC0uMDMuNjctLjA5cy4zNy0uMTMuNTItLjIxYy4xNS0uMDguMjktLjE3LjQtLjI3bC4zMS0uMjdjLjEyLjE1LjI1LjM1LjM4LjU4cy4yLjQzLjIuNThjMCAuMjItLjEzLjQyLS4zOC42MS0uMjEuMTYtLjUxLjMtLjkxLjQyLS4zOS4xMS0uODUuMTctMS4zOC4xNy0uNDggMC0uOTUtLjA2LTEuNDEtLjE4LS40Ni0uMTItLjg3LS4zNC0xLjIzLS42NC0uMzYtLjMxLS42NS0uNzEtLjg3LTEuMjMtLjIyLS41MS0uMzQtMS4xNi0uMzQtMS45NCAwLS42NC4xLTEuMTkuMy0xLjY2LjItLjQ2LjQ3LS44NS44LTEuMTUuMzMtLjMuNzEtLjUzIDEuMTItLjY3cy44NS0uMjEgMS4yOC0uMjFjLjU3IDAgMS4wNi4wOSAxLjQ1LjI2cy43Mi40Mi45Ny43Mi40My42NC41NCAxLjAzYy4xMS4zOC4xNy43OS4xNyAxLjIydi4yMWwtLjAxLjI2LS4wMS4yN2MwIC4wOS0uMDEuMTYtLjAyLjIxaC00LjV6bTIuNjUtMS4xNGMwLS40OS0uMDktLjg5LS4yOC0xLjE5cy0uNTMtLjQ2LTEuMDEtLjQ2Yy0uNDIgMC0uNzUuMTQtMSAuNDNzLS4zNy42OS0uMzcgMS4yMWgyLjY3em00LjU4IDEuMTRjLjA0LjU2LjIyIDEuMDIuNTIgMS4zOS4zMS4zNy43OS41NSAxLjQ1LjU1LjI2IDAgLjQ4LS4wMy42Ny0uMDlzLjM3LS4xMy41Mi0uMjFjLjE2LS4wOC4yOS0uMTcuNC0uMjdsLjMxLS4yN2MuMTIuMTUuMjUuMzQuMzguNTguMTMuMjQuMi40My4yLjU4IDAgLjIyLS4xMy40Mi0uMzguNjEtLjIxLjE2LS41MS4zLS45MS40Mi0uMzkuMTEtLjg1LjE3LTEuMzguMTctLjQ4IDAtLjk1LS4wNi0xLjQxLS4xOC0uNDYtLjEzLS44Ny0uMzQtMS4yMy0uNjQtLjM2LS4zMS0uNjUtLjcyLS44Ny0xLjIzLS4yMi0uNTItLjMzLTEuMTctLjMzLTEuOTUgMC0uNjQuMS0xLjE5LjMtMS42Ni4yLS40Ny40Ny0uODUuOC0xLjE2LjMzLS4zMS43MS0uNTMgMS4xMi0uNjdzLjg1LS4yMiAxLjI4LS4yMmMuNTcgMCAxLjA2LjA5IDEuNDUuMjcuNC4xOC43Mi40Mi45Ny43MnMuNDMuNjQuNTUgMS4wM2MuMTIuMzkuMTcuNzkuMTcgMS4yMnYuNDdsLS4wMS4yNmMtLjAxLjA5LS4wMS4xNi0uMDIuMjFoLTQuNDl6bTIuNjUtMS4xNGMwLS40OS0uMDktLjg5LS4yOC0xLjE5LS4xOS0uMzEtLjUyLS40Ni0xLjAxLS40Ni0uNDEgMC0uNzUuMTQtMSAuNDNzLS4zNy42OS0uMzcgMS4yMWgyLjY3em03LjQ1LTEuMDFjLS4wOC0uMDgtLjIyLS4xOC0uNDItLjI5LS4yLS4xMS0uNDMtLjE3LS42OS0uMTctLjUzIDAtLjkyLjE5LTEuMTguNTgtLjI1LjM4LS4zOC45NC0uMzggMS42NiAwIC4zNS4wMy42OC4wOC45Ny4wNS4yOS4xNC41My4yNi43NC4xMi4yLjI5LjM2LjQ5LjQ3LjIxLjExLjQ3LjE2Ljc4LjE2LjMgMCAuNTUtLjA2Ljc2LS4xOXMuMzItLjMuMzItLjUydi0zLjR6bS43MiA1LjRjLS4xNyAwLS4zMS0uMDYtLjQxLS4xOC0uMTEtLjEyLS4xNi0uMjctLjE2LS40NS0uMTQuMTctLjM4LjM1LS43Mi41My0uMzQuMTktLjc3LjI4LTEuMy4yOC0uMzcgMC0uNzQtLjA2LTEuMDktLjE5LS4zNS0uMTItLjY2LS4zMy0uOTQtLjYxcy0uNDktLjY2LS42NS0xLjE0Yy0uMTYtLjQ4LS4yNC0xLjA2LS4yNC0xLjc2IDAtLjcxLjA5LTEuMy4yNS0xLjguMTctLjUuMzktLjkxLjY3LTEuMjJzLjYtLjU0Ljk2LS42OS43NC0uMjIgMS4xNC0uMjJjLjQ2IDAgLjg0LjA4IDEuMTMuMjMuMy4xNi41Mi4zMS42Ni40NlY0LjZjLjA3LS4wMi4xOC0uMDM1LjMyLS4wNDYuMTUtLjAxLjI3LS4wMTIuMzgtLjAxMi4xNyAwIC4zMy4wMS41LjA0cy4zMi4wOS40NS4xOC4yNC4yMS4zMS4zN2MuMDguMTYuMTIuMzYuMTIuNjJ2OC4zN2gtMS4zNnptMi41OS0uMDZjLS4yLS4yMi0uMy0uNDktLjMtLjgxcy4xMS0uNTkuMzItLjc5Yy4yMS0uMjEuNDctLjMxLjc5LS4zMXMuNTkuMS44LjNjLjIxLjIuMzIuNDcuMzIuNzkgMCAuMzItLjEuNTktLjMuOC0uMi4yMS0uNDcuMzItLjgxLjMyLS4zMyAwLS42LS4xLS44MS0uMzF6bTIuNzQtNy4wMmMuMDMtLjAxLjEyLS4wMy4yNS0uMDQuMTQtLjAyLjI4LS4wMi40NS0uMDJzLjMyLjAxLjQ4LjA0LjMxLjA4LjQ0LjE3LjI0LjIuMzIuMzZjLjA4LjE1LjEyLjM2LjEyLjYxdjYuMDdjLS4wNC4wMi0uMTMuMDMtLjI3LjA0LS4xNC4wMS0uMjkuMDEtLjQ1LjAxLS4yIDAtLjM4LS4wMi0uNTQtLjA1LS4xNi0uMDQtLjMtLjEtLjQxLS4yLS4xMi0uMS0uMjEtLjIyLS4yNy0uMzgtLjA3LS4xNi0uMS0uMzctLjEtLjYydi02em0wLTEuNjRjMC0uMzIuMTEtLjU5LjMyLS43OS4yMS0uMjEuNDctLjMxLjc4LS4zMS4zIDAgLjU2LjEuNzguMzEuMjIuMi4zMi40Ny4zMi43OSAwIC4zMi0uMTEuNTgtLjMyLjc4LS4yMS4yLS40Ny4zLS43Ny4zLS4zMSAwLS41Ny0uMS0uNzgtLjMtLjIxLS4yMS0uMzEtLjQ3LS4zMS0uNzl6bTMuNzMgNy44NWMtLjI4LS4zNS0uNDgtLjc2LS42MS0xLjIxcy0uMTktLjk0LS4xOS0xLjQ0YzAtLjUxLjA4LTEgLjIzLTEuNDUuMTUtLjQ2LjM3LS44Ni42Ny0xLjIxLjI5LS4zNS42Ny0uNjIgMS4xMi0uODIuNDUtLjIuOTctLjMgMS41OC0uMy42MyAwIDEuMTcuMSAxLjYxLjMuNDQuMi44MS40NyAxLjA4LjgxLjI4LjM0LjQ4LjczLjYgMS4xOC4xMy40NS4xOS45My4xOSAxLjQzcy0uMDYuOTgtLjE5IDEuNDRjLS4xMi40Ni0uMzMuODctLjYxIDEuMjJzLS42NS42My0xLjEuODRjLS40NS4yMS0xIC4zMS0xLjY0LjMxcy0xLjE5LS4xLTEuNjMtLjNjLS40NS0uMjEtLjgxLS40OC0xLjA5LS44MnptMS45OS0uNmMuMi4xMy40NS4xOS43NC4xOS4zIDAgLjU1LS4wNy43NS0uMnMuMzUtLjMuNDYtLjUyYy4xMS0uMjIuMTktLjQ2LjIzLS43M3MuMDYtLjU1LjA2LS44M2MwLS4yNy0uMDItLjU0LS4wNi0uODEtLjA0LS4yNy0uMTItLjUtLjIzLS43LS4xMS0uMi0uMjYtLjM2LS40NS0uNDlzLS40My0uMTktLjcyLS4xOS0uNTMuMDYtLjczLjE5LS4zNS4zLS40Ni41Yy0uMTEuMjEtLjIuNDQtLjI1LjctLjA1LjI2LS4wNy41My0uMDcuOHMuMDIuNTQuMDYuODEuMTMuNTEuMjQuNzNjLjExLjIxLjI2LjM4LjQ1LjUyeiIvPjxwYXRoIGQ9Ik0yMC4zMjUgMTIuNDJjLjE0Mi4wOC4zMDIuMTYuNDguMjM1cy4zNy4xNC41NzIuMTljLjIwMy4wNS40MTIuMDc2LjYyNS4wNzYuMTMyIDAgLjI3LS4wMS40MTItLjAzLjE0Mi0uMDIuMjY3LS4wNi4zNzQtLjEycy4xOTYtLjE0LjI2Ny0uMjRjLjA3LS4xLjEwNy0uMjMuMTA3LS4zOSAwLS4yOS0uMTE1LS41LS4zNDMtLjYzLS4yMy0uMTItLjU4LS4yMy0xLjAzLS4zMy0uMy0uMDYtLjU4LS4xNC0uODYtLjI0LS4yOC0uMS0uNTItLjIzLS43My0uNC0uMjItLjE3LS4zOS0uMzgtLjUxLS42My0uMTMtLjI1LS4xOS0uNTYtLjE5LS45M3MuMDgtLjY5LjI0LS45Ni4zOC0uNTEuNjUtLjdjLjI3LS4xOS41OC0uMzQuOTQtLjQzLjM1LS4xLjczLS4xNCAxLjExLS4xNC40IDAgLjc3LjAzIDEuMDkuMDkuMzIuMDYuNTkuMTQuODMuMjUuNDUuMTguNjguNDIuNy43MiAwIC4xNS0uMDUuMzMtLjE1LjU0cy0uMi40LS4zMi41OWMtLjExLS4wOC0uMjMtLjE2LS4zOC0uMjUtLjE1LS4wOC0uMzEtLjE3LS41LS4yNC0uMTgtLjA3LS4zNy0uMTQtLjU3LS4xOXMtLjQtLjA3LS42MS0uMDdjLS4xMSAwLS4yMy4wMS0uMzUuMDJzLS4yMy4wNS0uMzMuMDljLS4xLjA1LS4xOC4xMi0uMjUuMi0uMDcuMDktLjEuMi0uMS4zNSAwIC4zNS4zNy42IDEuMTEuNzYuMy4wNi42LjE0LjkuMjQuMy4xLjU3LjIzLjgxLjQxcy40My4zOS41OC42NmMuMTUuMjYuMjIuNTkuMjIuOTkgMCAuNDEtLjA4Ljc3LS4yMyAxLjA4LS4xNi4zMS0uMzguNTgtLjY1Ljc5cy0uNi4zOC0uOTcuNDljLS4zNy4xMi0uNzguMTctMS4yMi4xNy0uNDUgMC0uODMtLjAzLTEuMTQtLjFzLS41Ny0uMTQtLjc3LS4yM2MtLjE0LS4wNi0uMy0uMTUtLjQ3LS4yNy0uMTctLjEyLS4yNS0uMjgtLjI1LS40OCAwLS4xNy4wNS0uMzUuMTUtLjU0LjEtLjE5LjIyLS4zOS4zNS0uNTkuMDkuMDkuMjEuMTcuMzQuMjd6bTYuNDk2LTguMTQ1Yy42IDAgMS4wOC40ODMgMS4wOCAxLjA3OHMtLjQ4IDEuMDc3LTEuMDggMS4wNzctMS4wNy0uNDgtMS4wNy0xLjA3NWMwLS41OTYuNDktMS4wNzggMS4wOC0xLjA3OHptLS45NyAyLjY1NWMuMDMtLjAxLjEyLS4wMjcuMjYtLjA0LjE0LS4wMTcuMjktLjAyNS40NS0uMDI1cy4zMy4wMTUuNDkuMDQ2Yy4xNy4wMy4zMS4wOS40NC4xOHMuMjQuMjEuMzIuMzcuMTIuMzcuMTIuNjJ2Ni4xNmMtLjA0LjAyLS4xMy4wNC0uMjcuMDUtLjE0LjAxLS4yOS4wMi0uNDUuMDItLjIgMC0uMzgtLjAyLS41NS0uMDUtLjE2LS4wMy0uMy0uMS0uNDItLjJzLS4yMS0uMjItLjI3LS4zOWMtLjA2LS4xNi0uMS0uMzctLjEtLjYydi02LjF6bTMuMDUtMi4yNzdsLjIzLS4wM2MuMDctLjAxLjE1LS4wMTguMjMtLjAyMy4wOC0uMDA0LjE3LS4wMDYuMjUtLjAwNi4xNyAwIC4zMy4wMTUuNDkuMDQ2cy4zMS4wOTMuNDUuMTg0LjI0LjIxNi4zMi4zNzQuMTIuMzYyLjEyLjYxN3YxLjA2OGgyLjE0VjguNDRoLTIuMTR2My4yNjVjMCAuNzEyLjI5IDEuMDY4Ljg3IDEuMDY4LjE0IDAgLjI4LS4wMjMuNDEtLjA3LjEzLS4wNDUuMjQtLjA5Ni4zNS0uMTUuMS0uMDU3LjE5LS4xMTYuMjctLjE3Ni4wOC0uMDYuMTMtLjEwNy4xNi0uMTM3LjE2LjIyNC4yNy40MTcuMzUuNTguMDkuMTYyLjEzLjMxNC4xMy40NTYgMCAuMTMyLS4wNS4yNjItLjE2LjM5cy0uMjYuMjQzLS40NS4zNWMtLjE5LjEwNy0uNDMuMTkzLS43LjI2LS4yNy4wNjUtLjU3LjA5OC0uOS4wOTgtLjYzIDAtMS4xMi0uMTIyLTEuNDctLjM2NnMtLjYtLjU2NC0uNzQtLjk2Yy0uMDctLjIwNS0uMTItLjQxOC0uMTQtLjY0Mi0uMDItLjIyNC0uMDMtLjQ0Ny0uMDMtLjY3di03LjA4em02LjkgNi4yMzdjLjA0LjU2LjIyIDEuMDMuNTIgMS40LjMxLjM3Ljc5LjU1NyAxLjQ1LjU1Ny4yNiAwIC40OC0uMDI4LjY3LS4wODRzLjM3LS4xMjUuNTItLjIwN2MuMTUtLjA4LjI5LS4xNy40LS4yNjZsLjMxLS4yN2MuMTIuMTUuMjUuMzQ3LjM4LjU4NnMuMi40MzQuMi41ODZjMCAuMjI1LS4xMy40MjgtLjM4LjYxLS4yMS4xNjQtLjUxLjMwMy0uOS40Mi0uMzkuMTE3LS44NS4xNzYtMS4zOC4xNzYtLjQ4IDAtLjk1LS4wNi0xLjQxLS4xODItLjQ2LS4xMi0uODctLjMzNC0xLjIzLS42NHMtLjY1LS43MTMtLjg3LTEuMjI3Yy0uMjItLjUyLS4zMy0xLjE3LS4zMy0xLjk1IDAtLjY0LjEtMS4xOS4zLTEuNjZzLjQ2LS44NS43OS0xLjE1Yy4zMy0uMzEuNy0uNTMgMS4xMi0uNjhzLjg1LS4yMiAxLjI4LS4yMmMuNTcgMCAxLjA1LjA5IDEuNDUuMjcuNC4xOC43Mi40MS45Ny43MXMuNDMuNjQuNTQgMS4wM2MuMTEuMzguMTcuNzkuMTcgMS4yMnYuMjFsLS4wMS4yNi0uMDEuMjZzLS4wMS4xNS0uMDIuMmgtNC41em0yLjY2LTEuMTRjMC0uNDktLjA5LS44ODQtLjI4LTEuMTlzLS41Mi0uNDYtMS4wMS0uNDZjLS40MSAwLS43NS4xNDgtMSAuNDM4cy0uMzcuNjk0LS4zNyAxLjIxMmgyLjY3em0zLjM3IDIuNjdjLjE0LjA4LjMxLjE2LjQ4LjIzNy4xOC4wNzYuMzcuMTQuNTguMTkuMjEuMDUuNDEuMDc2LjYzLjA3Ni4xNCAwIC4yNy0uMDEuNDItLjAzLjE1LS4wMi4yNy0uMDYuMzgtLjEyLjExLS4wNi4yLS4xNDQuMjctLjI0NnMuMTEtLjIzNC4xMS0uMzk2YzAtLjI5LS4xMS0uNS0uMzQtLjYzLS4yMy0uMTItLjU3LS4yMy0xLjAzLS4zMy0uMjktLjA2LS41Ny0uMTQtLjg1LS4yNC0uMjctLjEtLjUyLS4yMy0uNzMtLjQtLjIxLS4xNy0uMzgtLjM4LS41MS0uNjNzLS4xOS0uNTYtLjE5LS45My4wOC0uNjguMjQtLjk2Yy4xNy0uMjcuMzgtLjUxLjY1LS43LjI3LS4xOS41OC0uMzMuOTQtLjQzcy43My0uMTQgMS4xMS0uMTRjLjQxIDAgLjc3LjAzIDEuMDkuMDkuMzIuMDYuNi4xNS44My4yNS40NS4xOS42OS40Mi43MS43MiAwIC4xNi0uMDUuMzQtLjE0LjU0cy0uMi40MS0uMzEuNTljLS4xLS4wOC0uMjItLjE2LS4zNy0uMjVzLS4zMS0uMTctLjQ5LS4yNGMtLjE4LS4wNy0uMzctLjE0LS41Ny0uMTktLjItLjA1LS40LS4wNy0uNi0uMDctLjExIDAtLjIzLjAxLS4zNS4wM3MtLjIzLjA1LS4zMy4wOWMtLjEuMDUtLjE4LjExLS4yNC4yLS4wNi4wOC0uMS4yLS4xLjM0IDAgLjM1LjM3LjYgMS4xMi43Ni4zLjA2LjYxLjE0LjkxLjI0LjMuMS41Ny4yMy44MS40MXMuNDMuMzkuNTguNjYuMjIuNi4yMi45OWMwIC40MS0uMDguNzctLjI0IDEuMDktLjE2LjMyLS4zOC41OC0uNjUuNzlzLS42LjM4LS45Ny40OWMtLjM3LjEyLS43Ny4xNy0xLjIxLjE3LS40NSAwLS44My0uMDMtMS4xNC0uMXMtLjU2LS4xNC0uNzctLjIzYy0uMTQtLjA2LS4zLS4xNS0uNDYtLjI3LS4xNy0uMTEtLjI1LS4yNy0uMjUtLjQ4IDAtLjE3LjA1LS4zNS4xNS0uNTQuMS0uMTkuMjItLjM4LjM1LS41OS4wOS4wOS4yMS4xNy4zNC4yNnptNS41NS01LjQ5bC4xOS0uMDNjLjA2LS4wMS4xNC0uMDIuMjItLjAyMy4wOC0uMDA1LjE4LS4wMDguMjktLjAwOC4zNCAwIC42Mi4wNS44Ni4xNnMuMzguMy40NC41NmMuMTctLjIuNDItLjM5Ljc3LS41OXMuNzktLjMgMS4zMS0uM2MuMzggMCAuNzQuMDYgMS4wOC4xOXMuNjQuMzMuOTEuNjIuNDguNjYuNjMgMS4xM2MuMTYuNDcuMjQgMS4wNC4yNCAxLjcyIDAgLjc5LS4wOSAxLjQ0LS4yNyAxLjk2LS4xOC41MS0uNDIuOTItLjcxIDEuMjJzLS42MS41MS0uOTYuNjMtLjcxLjE4LTEuMDYuMThjLS4zIDAtLjU1LS4wNC0uNzctLjEtLjIyLS4wNy0uNC0uMTQtLjU2LS4yMi0uMTUtLjA4LS4yNy0uMTctLjM1LS4yNS0uMDgtLjA5LS4xMy0uMTQtLjE1LS4xN3YyLjNINDcuNHYtOXptMi4wOCA1LjM1Yy4wOS4wOC4yMy4xOC40NC4yOS4yMS4xMS40NS4xNy43My4xNy41MiAwIC45LS4yMDIgMS4xNS0uNjFzLjM3LS45NzUuMzctMS43MWMwLS4zMDQtLjAzLS41OS0uMDgtLjg1M3MtLjEzLS40OTMtLjI1LS42ODYtLjI3LS4zNC0uNDctLjQ1Yy0uMi0uMTEtLjQ0LS4xNi0uNzItLjE2LS40MiAwLS43Mi4wOC0uODkuMjUtLjE3LjE3LS4yNS4zNC0uMjUuNTR2My4yM3ptNy42Ni0xLjM5Yy4wNC41Ni4yMiAxLjAzLjUyIDEuNC4zMS4zNy43OS41NTUgMS40NS41NTUuMjYgMCAuNDgtLjAyNi42Ny0uMDgycy4zNy0uMTIyLjUyLS4yMDRjLjE1LS4wOC4yOS0uMTcuNC0uMjdsLjMxLS4yN2MuMTIuMTUuMjUuMzUuMzguNTlzLjIuNDMuMi41OGMwIC4yMi0uMTMuNDMtLjM4LjYxLS4yMS4xNi0uNTEuMy0uOTEuNDJzLS44NS4xNy0xLjM4LjE3Yy0uNDggMC0uOTUtLjA2LTEuNDEtLjE5LS40Ni0uMTMtLjg3LS4zNC0xLjIzLS42NC0uMzYtLjMxLS42NS0uNzItLjg4LTEuMjMtLjIyLS41MS0uMzMtMS4xNi0uMzMtMS45NSAwLS42NC4xLTEuMTkuMy0xLjY2LjItLjQ3LjQ2LS44NS43OS0xLjE1LjMzLS4zMS43LS41MyAxLjEyLS42N3MuODQtLjIyIDEuMjgtLjIyYy41NyAwIDEuMDUuMDkgMS40NS4yNnMuNzIuNDEuOTcuNzEuNDMuNjQuNTQgMS4wM2MuMTEuMzguMTcuNzkuMTcgMS4yMnYuMjFsLS4wMS4yNi0uMDIuMjZjMCAuMDktLjAxLjE1LS4wMi4yMWgtNC41em0yLjY1LTEuMTRjMC0uNDktLjA5LS44ODItLjI4LTEuMTlzLS41Mi0uNDU0LTEuMDEtLjQ1NGMtLjQxIDAtLjc1LjE0NS0xIC40MzVzLS4zNy43LS4zNyAxLjIxaDIuNjd6bTQuNTggMS4xNDdjLjA0LjU2LjIyIDEuMDI0LjUyIDEuMzk1LjMxLjM3Ljc5LjU1NCAxLjQ1LjU1NC4yNiAwIC40OC0uMDI4LjY3LS4wODRzLjM3LS4xMjUuNTItLjIwN2MuMTUtLjA4LjI5LS4xNy40LS4yNjdsLjMxLS4yNjhjLjEyLjE1Mi4yNS4zNDcuMzguNTg2LjE0LjIzOC4yLjQzNC4yLjU4NiAwIC4yMjYtLjEzLjQzLS4zOC42MS0uMjEuMTY1LS41MS4zMDQtLjkuNDItLjM5LjExOC0uODUuMTc2LTEuMzguMTc2LS40OCAwLS45NS0uMDYtMS40MS0uMTgzLS40Ni0uMTIyLS44Ny0uMzM2LTEuMjMtLjY0LS4zNi0uMzA1LS42NS0uNzE0LS44Ny0xLjIyOC0uMjItLjUxNC0uMzMtMS4xNjMtLjMzLTEuOTQ2IDAtLjY0LjEtMS4xOS4zLTEuNjUuMi0uNDYuNDctLjg0LjgtMS4xNS4zMy0uMy43LS41MyAxLjEyLS42N3MuODQtLjIxIDEuMjgtLjIxYy41NyAwIDEuMDUuMDkgMS40NS4yNy4zOS4xOC43Mi40Mi45Ny43MnMuNDMuNjUuNTUgMS4wM2MuMTEuMzkuMTYuOC4xNiAxLjIydi4yMnMwIC4xNy0uMDEuMjZsLS4wMS4yN2MtLjAxLjA5LS4wMS4xNi0uMDIuMjFINjQuNHYuMDF6TTY3IDkuNzU0YzAtLjQ4Ny0uMDk0LS44ODQtLjI4LTEuMTktLjE5LS4zMDQtLjUyOC0uNDU2LTEuMDE2LS40NTYtLjQxNiAwLS43NS4xNDUtMSAuNDM1cy0uMzcyLjY5NC0uMzcyIDEuMjFINjd6bTcuNDQtMS4wMDRjLS4wOC0uMDgtLjIyLS4xOC0uNDItLjI5LS4yLS4xMTQtLjQzLS4xNy0uNjk1LS4xNy0uNTMgMC0uOTIuMTkyLTEuMTguNTgtLjI1My4zODUtLjM4Ljk0LS4zOCAxLjY2IDAgLjM1Ni4wMjYuNjguMDc2Ljk3LjA1LjI5LjE0LjUzNC4yNi43NC4xMy4yLjI5LjM2LjQ5LjQ3LjIxLjExLjQ3LjE2Ni43OC4xNjYuMyAwIC41NS0uMDYuNzYtLjE4M3MuMzItLjI5My4zMi0uNTE2di0zLjQzem0uNzE1IDUuMzk2Yy0uMTc3IDAtLjMxLS4wNi0uNDE2LS4xNzUtLjEtLjExLS4xNS0uMjYtLjE1LS40NS0uMTQuMTgtLjM4LjM1LS43My41NC0uMzQuMTktLjc4LjI4LTEuMzEuMjgtLjM4IDAtLjc0LS4wNi0xLjA5LS4xOC0uMzUtLjEyLS42Ni0uMzItLjk0LS42MXMtLjQ5LS42Ni0uNjYtMS4xM2MtLjE2LS40Ny0uMjUtMS4wNi0uMjUtMS43NnMuMDgtMS4zLjI1LTEuOGMuMTctLjUuMzktLjkuNjctMS4yMXMuNi0uNTQuOTYtLjY4Ljc0LS4yMiAxLjE0LS4yMmMuNDUgMCAuODMuMDggMS4xMy4yNC4yOS4xNi41MS4zMi42NS40N1Y0LjYxYy4wNy0uMDIuMTgtLjAzNi4zMi0uMDQ3LjE0LS4wMS4yNy0uMDE0LjM4LS4wMTQuMTYgMCAuMzMuMDEuNS4wNHMuMzIuMDkuNDUuMTguMjQuMjEuMzEuMzdjLjA4LjE2LjExLjM2LjExLjYydjguMzdoLTEuMzV6bTIuNTktLjA1NmMtLjItLjIyLS4zLS40OS0uMy0uODEycy4xMDQtLjU4NC4zMTUtLjc5Yy4yMS0uMjA1LjQ3Ni0uMzA3Ljc5Ny0uMzA3cy41ODcuMTEuOC4zMWMuMjEuMjEuMzE1LjQ3LjMxNS43OSAwIC4zMi0uMS41OS0uMy44MS0uMi4yMi0uNDcuMzMtLjgxLjMzLS4zMy4wMS0uNi0uMS0uODEtLjMxem0yLjczNy03LjAyYy4wMy0uMDEuMTEtLjAyNC4yNDQtLjA0LjEzNS0uMDE0LjI4My0uMDIyLjQ0NC0uMDIycy4zMi4wMTUuNDguMDQ1LjMwNS4wODMuNDM1LjE3LjIzNS4yMDMuMzE1LjM2Yy4wOC4xNTQuMTIuMzYuMTIuNjF2Ni4wNzJjLS4wNC4wMi0uMTMuMDM1LS4yNy4wNDUtLjE0LjAxLS4yOS4wMTMtLjQ1LjAxMy0uMiAwLS4zOC0uMDE4LS41NC0uMDUzLS4xNi0uMDM2LS4zLS4xLS40MTctLjE5Ny0uMTItLjA5NS0uMjEtLjIyMy0uMjctLjM4My0uMDctLjE2LS4xLS4zNjYtLjEtLjYxNnYtNi4wMXptLS4wMDctMS42NGMwLS4zMi4xMDMtLjU4My4zMTQtLjc5LjIxLS4yMDQuNDctLjMxLjc4LS4zMS4zIDAgLjU2LjEwNi43Ny4zMS4yMS4yMDYuMzIuNDcuMzIuNzkgMCAuMzItLjExLjU4LS4zMi43OC0uMjIuMi0uNDguMy0uNzguMy0uMzEgMC0uNTgtLjEtLjc5LS4zLS4yMS0uMi0uMzEtLjQ2LS4zMS0uNzh6bTMuNzMgNy44NDhjLS4yOC0uMzUtLjQ4Ny0uNzU0LS42MTctMS4yMXMtLjE5NS0uOTM1LS4xOTUtMS40MzZjMC0uNTEuMDczLS45OTQuMjIzLTEuNDUuMTUzLS40NTYuMzc1LS44Ni42Ny0xLjIwMy4yOTctLjM1LjY3LS42MiAxLjEyLS44Mi40NS0uMi45NzgtLjMgMS41OC0uMy42MyAwIDEuMTcuMSAxLjYxNi4zLjQ0My4yLjgwNC40NyAxLjA4LjgxLjI3NC4zNC40NzQuNzMuNiAxLjE4LjEyMi40NS4xODUuOTIuMTg1IDEuNDJzLS4wNjQuOTgtLjE5IDEuNDRjLS4xMy40Ni0uMzM1Ljg2LS42MiAxLjIyLS4yODcuMzUtLjY1NS42My0xLjEwNi44NC0uNDUuMjEtLjk5LjMxLTEuNjQuMzFzLTEuMTgtLjExLTEuNjMtLjMxYy0uNDQtLjIxLS44MS0uNDgtMS4wOS0uODJ6bTEuOTg0LS42Yy4yLjEzLjQ0LjE5NC43My4xOTQuMyAwIC41NS0uMDY0Ljc0LS4xOTRzLjM1LS4zMDMuNDYtLjUyYy4xMS0uMjE0LjE4LS40NTcuMjItLjcyOHMuMDYtLjU0Ni4wNi0uODI3YzAtLjI3LS4wMi0uNTQtLjA2LS44MDQtLjA0LS4yNy0uMTItLjUtLjIzLS43LS4xMS0uMi0uMjYtLjM3LS40NS0uNDktLjE5LS4xMy0uNDMtLjE5LS43Mi0uMTlzLS41NC4wNi0uNzMuMTktLjM1LjMtLjQ3LjUtLjIuNDQtLjI1LjdjLS4wNS4yNi0uMDguNTItLjA4Ljc5cy4wMi41NC4wNy44MS4xMi41MS4yMy43M2MuMTEuMjEuMjYuMzguNDUuNTF6Ii8+PC9nPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTUuOTcgNC4wMWwuMjIzLS41ODUuMDAyLS4wMDRjLjEyLS4zNC4yNjctLjY4LjM3OC0xLjAzLjA5LS4yOC4xNjctLjYxIDAtLjg4LS4xNjgtLjI3LS40OTQtLjM0LS43OTUtLjM2LS40MjMtLjAyLS45MDQuMDUtMS4zMjMuMTFsLTEuNDEzLjJDMTEuODMyLjU1IDEwLjMzNy4wMiA4LjcxNi4wMlM1LjYuNTUgNC4zOSAxLjQ0NWwtMS40MTMtLjE5M2MtLjQyLS4wNTctLjktLjEyMi0xLjMyMy0uMTAyLS4zLjAxOC0uNjI3LjA4Ny0uNzk2LjM2LS4xNjYuMjctLjA5LjYgMCAuODguMTEyLjM1LjI1Ny42OS4zOCAxLjAzNXYuMDA0bC41OSAxLjU0Yy0uMjQ1LjcyLS4zNzggMS41LS4zNzggMi4zMSAwIDEuNDEuNDEgMi43NCAxLjM1NCAzLjgyLjA5My4xLjE5LjIuMjkuM2wtLjAwNS4wMmMtLjQ3LjA1LS45NC0uMTYtMS4yMi0uNTgtLjA0LS4wNi0uMDYtLjE2LS4wNy0uMjItLjAzLS4xMS0uMDctLjItLjEzLS4yOS0uMjctLjQyLS44My0uNTQtMS4yNS0uMjctLjQ4LjMxLS40OS44MS0uMjYgMS4yOC4wNS4xMS4xMS4yMi4xOC4zMi42NSAxIDEuODQgMS40NSAyLjk0IDEuMTkuMDQuMTMuMDkuMjUuMTQuMzYtLjE5LjAzLS4zOS4wMy0uNTYtLjAxbC0uMjMtLjA1LS4wOS4yMWMtLjE4LjQ0LS4yNi45MS0uMjIgMS4zOGwuMDIuMiAxLjAyIDEuMTktLjA1LjAyLS40Mi4xNS4yOC4zMmMuMDMuMDQuMDcuMDguMS4xMkw0LjMgMTcuOWwuMDMuMDMuMDI1LjAzLjAzLjAzLjAzLjAzLjAzLjAzLjAzLjAzLjAzLjAzLjAzMy4wMy4wMzQuMDMuMDMuMDMuMDMzLjAzLjAzNS4wMjMuMDM3LjAzLjAzNS4wMy4wMzQuMDMuMDM0LjAyNS4wMzcuMDMuMDM2LjAzLjA0LjAzLjAzMi4wMjIuMDQuMDMuMDM0LjAyNi4wNC4wMjIuMDQuMDI3LjA0LjAyNy4wNC4wMjUuMDQuMDI0LjA0LjAzLjA0LjAyLjA0LjAyLjA2LjAzLjEzLjA3LjA1LjAzLjE3LS4xOC4wMi0uMDIuMDItLjAyLjAzLS4wMi4wMi0uMDIuMDMtLjAyLjAzLS4wMi4wMy0uMDIuMDMtLjAyLjAzLS4wMS4wMy0uMDEuMDQtLjAxLjA0LS4wMS4wMy0uMDEuMDQtLjAxLjA0LS4wMS4wNC0uMDFoLjA0bC4wNC0uMDEuMDQtLjAxaC4zbC4wNC4wMS4wNC4wMS4wNC4wMS4wNC4wMS4wNC4wMS4wMi4wMDcuNDguOTguMjEuMDNoLjA2bC4wNi4wMWguMDZsLjA1LjAxaC4yM2wuMDUuMDEuMDUuMDFoLjg4NWwuMDYtLjAwN2guMTFsLjA2LS4wMS4wNi0uMDA4LjA2LS4wMDIuMDU1LS4wMS4wNi0uMDEuMDYtLjAxLjA2LS4wMDUuMDYtLjAxLjA2LS4wMS4yMi0uMDMuNDctLjk0Yy4wNC0uMDMuMDgtLjA0LjEyLS4wNmwuMDUtLjAxaC4wNGwuMDUtLjAxLjA0LS4wMS4wNC0uMDA0aC4xM2wuMDQuMDFIMTFsLjA0NC4wMS4wNC4wMDUuMDQuMDEuMDQuMDA1LjA0LjAxLjA0LjAxLjA0LjAxLjAzNy4wMTIuMDQuMDE1LjA0LjAxLjA0LjAyLjAzLjAxLjAzLjAyLjAzLjAyLjAzLjAyLjAzLjAyLjAzLjAyLjAyLjAyLjAyLjAyLjE4LjE5LjA1LS4wMy4xMy0uMDcuMDYtLjAzLjA1LS4wMi4wNC0uMDMuMDUtLjAyLjA0LS4wMi4wNC0uMDIyLjA0LS4wMjUuMDQtLjAyLjA0LS4wMjcuMDMtLjAyLjA0LS4wMi4wNC0uMDI0LjAzLS4wMy4wNC0uMDMuMDQtLjAzLjAzLS4wMy4wNC0uMDIuMDQtLjAzLjAzNi0uMDIuMDMtLjAzLjAzLS4wMy4wMy0uMDMuMDM2LS4wMy4wMy0uMDMuMDMtLjAyNy4wMy0uMDMuMDMtLjAzLjAzLS4wMy4wMy0uMDMuMDMtLjAzLjAzLS4wMyAxLjAzLTEuMTRjLjA0LS4wMy4wNy0uMDcuMTEtLjExbC4yOC0uMzItLjQyLS4xNWMtLjAyLS4wMS0uMDQtLjAxLS4wNS0uMDJsMS4wMi0xLjE4Ny4wMi0uMi4wMS0uMTRjLjc4LjI2IDEuNjYuMzUgMi4yNi4xLjAyLS4wMS4wNC0uMDIuMDUtLjA0LjQ0NC0uMjEuNzE1LS42NC44My0xLjExLjEzLS41LjA5LTEuMDU2LS4wOC0xLjU0Ni0uMTMtLjQxLS4zNi0uOC0uNjktMS4wODUtLjMtLjI2LS42OC0uNDQtMS4wOC0uNDEtLjAzIDAtLjA2IDAtLjA5LjAxbC0uMjctLjUzYy44NC0uNzYgMS4zMy0xLjg0IDEuMzMtMi45OCAwLTEuMjItLjU0LTIuMzEtMS40LTMuMDR6bS0xLjI0NiA2Ljk4Yy4wNTUtLjA2NS4xMDgtLjEzMi4xNi0uMmwuMzIzLjYzNWMtLjA1OC4wMzYtLjEyLjA1OC0uMTcyLjA0Ny0uMTU4LS4wMzItLjI2Ni0uMzE2LS4zMS0uNDh6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNGRkYiIGQ9Ik0xLjU4MiAxMS4wNDRjLjMzLjUxMi45Ljc3NiAxLjQ2OC43NDIuMDA1LjIzOC4wNTguNS4xMzMuNzU3LS45NS4yMDYtMS45NzMtLjE4LTIuNTMyLTEuMDQ2LS4yMS0uMzMzLS40Ni0uODM0LS4wMi0xLjEyLjI2LS4xNjUuNi0uMDkyLjc2LjE2NC4xLjE2LjA5LjM0LjIuNTF6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiM2Rjk0MjYiIGQ9Ik0xMy43MDggMTYuMTU1bDEuMDgzLTEuMjQ0Yy0uMjgtLjA1LS41OS0uMDQtLjg3LjA2LS4yNy4xLS41Ny4zMS0uNTcuNjMuMDEuMjQuMTcuNDMuMzYuNTd6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNEQ0IwMDAiIGQ9Ik0xMy4yNTUgMTcuMzM2Yy0uMzMzLjM5OC0uNjYyLjc0LTEuMTEgMS4wMmwuNTQ0LS42ODRjLjE5LS4xMDUuMzgtLjIxMy41Ni0uMzM2em0tNy45NTcgMS4wMmMtLjQzNi0uMjgyLS43NDgtLjYyNC0xLjEwNi0xLjAyLjE4Mi4xMjMuMzcuMjMuNTY0LjMzNmwuNTQyLjY4M3ptLjI3Ni4xNjJsLS43NC0uOTNjLjM1LS4zODQuOTg0LS41MSAxLjUtLjQybC41MjYuOTcyLS4wMS0uMDAyYy0uNDUtLjA2Mi0uOTU0LjA0My0xLjI3Ni4zOHptLjkzLTEuMzE0Yy40MjIuMTI0Ljk1LjUyLjcxMyAxLjA0Mi0uMDY1LS4wMy0uMTMtLjA1Mi0uMi0uMDcybC0uNTE0LS45N3ptMy42MDggMS4yNTNsLS4zMzIuNzE3Yy0uNy4wOS0xLjQxNC4wOS0yLjExNCAwbC0uMzMyLS43MTdjLjkwOC4xMiAxLjg3LjEyIDIuNzc4IDB6bS4yNS0uMjYyYy0uMDQ1LjAxNC0uMDkuMDMyLS4xMy4wNS0uMjE2LS40Ny4yMDUtLjg2OC42MjgtMS4wMTRsLS41Ljk3em0xLjUxLjMyMmMtLjMzNS0uMzUtLjg2LS40NS0xLjMyNS0uMzdsLS4wMTUuMDAzLjUtLjk2OGMuNTMtLjExOCAxLjIxIDAgMS41OC40MDNsLS43NC45MzJ6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNCQTAwMDAiIGQ9Ik0zLjc0IDE2LjE1NUwyLjY1NSAxNC45MWguMDA0Yy4yOC0uMDUzLjU5LS4wNC44Ny4wNTIuMjcuMDkzLjU3LjMwNS41Ny42MjUtLjAxLjIzNS0uMTcuNDMtLjM2LjU2OHoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iIzlDMyIgZD0iTTEzLjc4NSAxNi43M2MuMDg3LS4wOC4xNjgtLjE2NS4yNDQtLjI1LS42NS0uMjI4LS45OC0uNzM3LS43Ni0xLjE4LjIxLS40MzMuODgtLjY1MyAxLjU0LS41MyAwLS4wNzMuMDEtLjE0NS4wMS0uMjE4LS41MS0uMjA0LS45NS0uNDc2LTEuMTktLjc2LS4xNC0uMTU4LS4yNS0uMzI2LS4zNS0uNTAzLS4wNy0uMDUtLjEzLS4wOS0uMTgtLjE0LS4zNy40NC0uNzcuODItMS4yIDEuMTNsLS4wMS4wMWMtLjEuMTktLjIxLjM5LS4zNC41OC0uMDYuMjItLjE3LjQyLS4zNC42MWwyLjU1IDEuMjR6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNGMDAiIGQ9Ik0zLjU1MiAxMy41MTVjLS4yMzcuMDQ1LS40ODguMDQ4LS43MjUuMDAzLS4xNjguNDEzLS4yMzIuODM2LS4xOTQgMS4yNS42NjItLjEyMiAxLjMzMy4wOTggMS41NDQuNTMyLjIxNi40NDMtLjExNy45NTItLjc2IDEuMTc4LjEuMTE0LjIxLjIyNS4zMy4zM2wyLjUzNi0xLjI0NWMtLjE4OC0uMTk0LS4zMjMtLjQxMi0uMzktLjY0Ni0uMDMtLjA0LS4wNTYtLjA4LS4wODItLjEyMi0uMTguMTUtLjQ0LjE3Ny0uNjkuMTUtLjgxLS4wODUtMS4yLS42My0xLjUxLTEuMzE1bC0uMDUtLjExNXoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0ZDMCIgZD0iTTguNzI0IDE4LjM5NGMuNDYuMDA4LjkyNC0uMDE4IDEuMzgyLS4wOC0uMjM0LS40OTcuMDkyLTEuMDMyLjc2Ny0xLjIzNy42NjctLjIwMyAxLjQ1NS0uMDE3IDEuODQ4LjQxNy4zNi0uMTkzLjY3LS40MS45NC0uNjQ0bC0yLjU0LTEuMjM2Yy0uNTIuNS0xLjM5LjgzLTIuMzkuODMtLjk1IDAtMS43OS0uMjk3LTIuMzEtLjc1OGwtMi41MiAxLjI0Yy4yNS4yMDYuNTMuMzk2Ljg1LjU2OC40LS40MzMgMS4xOC0uNjIgMS44NS0uNDE3LjY4LjIwNSAxIC43NC43NyAxLjIzOC40Ni4wNi45Mi4wODYgMS4zOC4wOHoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iIzAwOTVEMiIgZD0iTTQuMTk1IDEyLjI0N2MyLjMzIDMuNTU3IDYuNzEzIDMuNTU3IDkuMDQzIDAtMS4zNC43OTctMi45NzggMS4xMDUtNC41MiAxLjEwNXMtMy4xODMtLjMxLTQuNTIzLTEuMTA1eiIvPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBmaWxsPSIjMDA1MTdDIiBkPSJNNC4xOTQgMTIuMjQ2YzEuMTI0IDEuNzE2IDIuNzI1IDIuNjA1IDQuMzQ0IDIuNjY2LjEtLjAwNC4yMDItLjAxLjMwMy0uMDItMS4zNi0uMTQtMi42OS0uODY3LTMuNzEtMi4xODQtLjMyLS4xMy0uNjMtLjI4NS0uOTMtLjQ2MnoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0ZGRiIgZD0iTTguNzE2LjQ1MmMxLjUyIDAgMi45MjcuNDk4IDQuMDYyIDEuMzRsMS4wODQtLjFjLjQ4Mi0uMDY2Ljk2NS0uMTQzIDEuNDUtLjE3NyAxLjQ2LS4xMDIgMS4wMzYuNDEuNTUgMS43OWwtLjE4NC40NzhjLS4yNy0uMTktLjU2Mi0uMzQ4LS44NzQtLjQ2Ny0uMDg0LS4xMy0uMTczLS4yNTUtLjI2NS0uMzc4LjAzLS4wNC4wNi0uMDguMDktLjExNy40NC0uNS45Ni0uODUgMS40OC0xLjAyLS45Mi0uMDctMS41Ny42LTIuMDMgMS4yN2wuMDUuMDdjLS4yNS0uMDUtLjUxLS4wNy0uNzctLjA3LTIuMjEgMC00LjAxIDEuOC00LjAxIDQuMDFzMS43OSA0LjAxIDQgNC4wMWMuMjYgMCAuNTItLjAyLjc4LS4wNy0xLjI1IDEuMy0zLjIyIDEuOTQtNS40MyAxLjk0LTMuNzggMC02Ljg0LTEuODYtNi44NC01LjYzIDAtMS42LjU1LTMuMDggMS40OC00LjI1LS40My0uNjctMS4xMy0xLjM5LTIuMDUtMS4yNS41MS4xNyAxLjAzLjUzIDEuNDcgMS4wM2wuMS4xMmMtLjM1LjQ3LS42NS45OC0uODggMS41M2wtLjQ0LTEuMThjLS40OC0xLjM2LS45LTEuODguNTEtMS43OS40NC4wMy44Ny4wOSAxLjMxLjE1LjQyLjA3Ljg0LjEgMS4yNi4xM0M1Ljc5Ljk1IDcuMTkuNDUgOC43MS40NXptNC42NTQgNC4wMTJjLTEuNDMgMC0yLjU5IDEuMTYtMi41OSAyLjU5IDAgMS40MzIgMS4xNiAyLjU5MiAyLjU5IDIuNTkyczIuNTktMS4xNiAyLjU5LTIuNTljMC0xLjQzMi0xLjE2LTIuNTkyLTIuNTktMi41OTJ6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNFN0U4RTkiIGQ9Ik02LjMxMyAxMi42MzdjLTIuNTg4LS42NS00LjQzLTIuNDI2LTQuNDMtNS4zNTMgMC0uNjMyLjA4Ni0xLjI0NC4yNDctMS44MjUuMjQ4LS44OC42NjUtMS43MSAxLjIzMi0yLjQybC4wMDMtLjAxYy0uNDM3LS42Ny0xLjEzNy0xLjM5LTIuMDQ4LTEuMjUuNTEuMTcgMS4wMzYuNTIgMS40NzggMS4wMy4wMzQuMDQuMDY3LjA3LjA5OC4xMS0uMzUuNDctLjY0Ni45OC0uODc2IDEuNTNMMS41NyAzLjNjLS40OC0xLjM2NS0uOTAyLTEuODgyLjUxLTEuNzkuNDM4LjAyNy44NzQuMDg4IDEuMzEuMTUuNDIzLjA2Ljg0LjA5NiAxLjI2Ny4xMjUuMDktLjA2Ny4xODMtLjEzMi4yNzctLjE5NC42NS0uNDMgMS4zOC0uNzUgMi4xNjItLjk0LTIuNDMzIDEuMTEtNC4xMzggMy42OC00LjEzOCA2LjY4IDAgMi42NiAxLjM0NyA0LjQzIDMuMzU1IDUuMzJ6Ii8+PHBhdGggZD0iTTkuNDQ2IDEwLjMzM2MuMjI0LjAzLjUzMi0uMTkzLjc0Ny0uMzUuMjUyLS4xODIuMjItLjA1OC4wNzIuMTItLjE5Mi4yMzYtLjQuNDktLjcxMi41NC0uMS4wMTYtLjE5NS4wMTItLjI4Mi0uMDAyLS4xMS0uMDEtLjIxLS4wNS0uMjctLjA4LS4xMy0uMDctLjI0LS4xLS4zNC0uMS0uMSAwLS4yLjA0LS4zNC4xMS0uMDYuMDQtLjE2LjA3LS4yNy4wOS0uMDguMDItLjE4LjAyLS4yOC4wMS0uMzEtLjA1LS41Mi0uMy0uNzEtLjU0LS4xNy0uMi0uMTUtLjI4LjA3LS4xMi4yMi4xNi41My4zOC43NS4zNS4yMi0uMDMuNDEtLjA3LjUzLS4xNS4xMS0uMDcuMTctLjE5LjEzLS4zOGwtLjAxLS4wNmMtLjM4LS4zNy0uNzgtLjI2LS45Mi0uNDktLjA3LS4xMy0uMDQtLjI1LjA1LS4zNi4zLS4zNyAxLjc1LS4zNyAyLjA1IDAgLjA5LjExLjEzLjI0LjA1LjM3LS4xMy4yMi0uNTIuMTItLjg4LjQ2IDAgLjA0LS4wMS4wNy0uMDEuMS0uMDQuMTkuMDEuMzEuMTIuMzl2LjAxYy4xMi4wOC4yOS4xMi41MS4xNXoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0YwMCIgZD0iTTE1LjY3OCA5Ljk2bC4zNDguNjgtLjA2Ni4wMjdjLS4yMzUuMTA4LS40Mi4yNzctLjU2NC40OGwtLjM5LS43NjNjLS40OTQuMjQzLTEuMDUuMzgtMS42MzcuMzgtMi4wNSAwLTMuNzEtMS42NjItMy43MS0zLjcxIDAtMi4wNSAxLjY2LTMuNzEgMy43MS0zLjcxIDIuMDQgMCAzLjcxIDEuNjYgMy43MSAzLjcxIDAgMS4xNzctLjU1IDIuMjI1LTEuNDEgMi45MDV6TTEzLjM3IDQuMTdjMS41OTMgMCAyLjg4NSAxLjI5IDIuODg1IDIuODg0IDAgMS41OTMtMS4yOTIgMi44ODUtMi44ODUgMi44ODUtMS41OTMgMC0yLjg4NS0xLjMtMi44ODUtMi44OXMxLjI5Mi0yLjg5IDIuODg1LTIuODl6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiM5QTAwMDAiIGQ9Ik0xNS4zOTYgMTEuMTQ4bC0uMzktLjc2M2MuMTAzLS4wNC4wMS4wMDUuMTEtLjA0NGwuMzY3LjctLjA4Ny4xMnptLTEuODQtLjM4OGMtLjA2LjAwMy0uMTIzLjAwNS0uMTg2LjAwNS0yLjA1IDAtMy43MS0xLjY2LTMuNzEtMy43MSAwLTIuMDQ4IDEuNjYtMy43MSAzLjcxLTMuNzEuMDYzIDAgLjEyNS4wMDIuMTg3LjAwNS00LjkwMy4yODgtNS4wODIgNy4wOTIgMCA3LjQxem0wLTYuNTg0YzEuNTA3LjA5NyAyLjcgMS4zNSAyLjcgMi44OCAwIDEuNTMtMS4xOTMgMi43ODItMi43IDIuODc4LjA2My4wMDQuMTI2LjAxNC4xODguMDA2IDMuNzA2LS40OTIgMy40NTMtNS40NzMgMC01Ljc3LS4wNjItLjAwNi0uMTI1LjAwMi0uMTg3LjAwNnoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0ZGRiIgZD0iTTE3Ljc3MyAxMi4xOTJjLjMwMi45LjA2IDEuODU1LS41NDMgMi4xMy0uNjAyLjI3Ny0xLjMzNS0uMjMtMS42MzctMS4xMy0uMzAyLS45LS4wNi0xLjg1NC41NDMtMi4xMy42MDItLjI3NiAxLjMzNS4yMyAxLjYzNyAxLjEzem0tMy40NDgtMS4wMTZjLjE0Ny40ODQuNDMuNzQuNzUzLjczLS4wOTQuNDctLjA0Ny45NzQuMTA0IDEuNDI1LjEzNy40MS4zNjcuOC42OSAxLjA5bC4wMzYuMDNjLTEuMjU0LS4xNC0yLjA3OC0uNzktMi40MjQtMS43OS4xODQtLjI2LjM1Ny0uNTUuNTE3LS44NWwuMjYtLjQ4LjA3LS4xNHoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0QxRDNENCIgZD0iTTE2LjQzOCAxNC4yODNjLS4zNTMtLjE4My0uNjctLjU3LS44NDUtMS4wOS0uMjktLjg2LS4wOC0xLjc3LjQ2NS0yLjA5LS4zNzQuNTItLjQ3IDEuMzc4LS4xOTUgMi4yLjEzMy4zOTcuMzM2LjczMi41NzUuOTh6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMy4zNyA1LjU1Yy4xIDAgLjIuMDEuMjk1LjAzLS4xNjIuMDgtLjI3NC4yNS0uMjc0LjQ0MyAwIC4yNzMuMjMuNDk1LjUuNDk1cy41LS4yMjIuNS0uNDk1di0uMDg4Yy4zMS4yNzUuNS42NzUuNSAxLjEyIDAgLjgzLS42NyAxLjUwNC0xLjUgMS41MDRzLTEuNS0uNjgtMS41LTEuNTEuNjgtMS41MSAxLjUxLTEuNTF6TTYuMDI4IDYuNjk2Yy43MTYuMTkyIDEuMjE4Ljc4NCAxLjMzIDEuNDctLjMzNC0uNDg1LS44MzYtLjg2LTEuNDUtMS4wMjQtLjYxNC0uMTY0LTEuMjM2LS4wOS0xLjc2OC4xNjMuNDQtLjU0IDEuMTcyLS44IDEuODg4LS42MXoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iIzAwOTVEMiIgZD0iTTE0LjMyNSAxMS4xNzZjLjExMi4zNy4zMDMuNjA1LjUzLjY5My0uMTcyLjAzLS44MTUgMS4yOS0uNzYgMS43Ny0uMjczLS4yNy0uNDc4LS42MS0uNjEtLjk5LjE4My0uMjcuMzU2LS41NS41MTYtLjg2bC4yNi0uNDkuMDctLjE0eiIvPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBmaWxsPSIjRkZGIiBkPSJNOS4yIDE1LjMyNmMuNTY4LjQ5OCAxLjI3NC4zMTYgMS45MS0uNTUzLS42MTQuMzA4LTEuMjYuNDkyLTEuOTEuNTUzem0tLjk2NiAwYy0uNTcuNDk4LTEuMjc1LjMxNi0xLjkxLS41NTMuNjEyLjMwOCAxLjI1Ny40OTIgMS45MS41NTN6bS0zLjA2Ny0uODFjLS42NjQtLjA3LS45MzYtLjU2NC0xLjE2Ny0xLjA2Ni0uMzEzLS42OC0uNDctMS4xOS0uNTEtMS41MzYuNTc1IDEuMDU2IDEuMzA3IDEuODY4IDIuMTI1IDIuNDM3LS4wNDIuMTMtLjE3My4yLS40NDguMTd6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMwMDk1RDIiIGQ9Ik00LjA1NiAxMy41N2MtLjAyLS4wNC0uMDM4LS4wOC0uMDU2LS4xMi0uMzEzLS42OC0uNDctMS4xOS0uNTEtMS41MzYuMzEzLjU3NC42NzIgMS4wNzYgMS4wNjYgMS41MDdsLS4wMTYuMDFjLS4xNS4wNy0uMzIuMTItLjQ4NC4xNXoiLz48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0iI0JDQkVDMCIgZD0iTTIuODk0IDIuOTM3Yy0uMTk4LjI2NC0uMzc4LjU0My0uNTQuODM0LS4xODQtLjY5LS4zOS0xLjM1LS45My0xLjk0LjQ3Ny4xOS45Ni41MiAxLjM3Ljk5LjAzNS4wNC4wNjguMDguMS4xMnoiLz48L3N2Zz4=",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 9302
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 2.381999976933,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.33300000359305004,
+          "wait": 228.90000001643796,
+          "receive": 3.807999979471674,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.321Z",
+        "time": 235.50800001248717,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/arrow_down.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/arrow_down.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-length",
+              "value": "416"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "2.655ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"1a0-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/svg+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 416,
+            "mimeType": "image/svg+xml",
+            "text": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NS4zMzMiIGhlaWdodD0iMzguMDIxIiB2aWV3Qm94PSIwIDAgNjUuMzMzIDM4LjAyMSI+PHBhdGggZmlsbD0iIzlEOUQ5RCIgZD0iTTQzLjk1LjA0NmMtLjAzLjA0My0uMDYuMDg1LS4wODcuMTNsLTIuNTU2IDQuNDI1Yy02LjQxMyAxMS4wOS0xMi44MjcgMjIuMTc3LTE5LjI0IDMzLjI2NS0uMDI2LjA0Ni0uMDU0LjA5LS4wOS4xNTUtLjAzLS4wNDgtLjA1NC0uMDg0LS4wNzUtLjEyMmwtMTAuMDItMTcuMzQzQzcuOTU2IDEzLjc2IDQuMDMgNi45NjMuMTAyLjE2Ny4wOC4xMjUuMDUuMDg3LjAyMy4wNDcuMDI4LjAzNi4wMy4wMjMuMDM1LjAyM2MuMDMtLjAwMi4wNiAwIC4wOSAwaDQzLjcyM2MuMDM0IDAgLjA2OC4wMTQuMTAzLjAyMnoiLz48L3N2Zz4=",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 1016
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 2.16400000499561,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.26200001593680033,
+          "wait": 230.0070000055716,
+          "receive": 3.074999985983169,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.322Z",
+        "time": 235.66800000844523,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/logos/logoFooter.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/logos/logoFooter.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "2.677ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4027-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/svg+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 16423,
+            "mimeType": "image/svg+xml",
+            "text": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjMiIGhlaWdodD0iMjUuMzc1IiB2aWV3Qm94PSIwIDAgMTIzIDI1LjM3NSI+PGcgZmlsbD0iIzAyNEY3RCI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC43MzUgNS4xOTNsLjI5LS43Ni4wMDMtLjAwNWMuMTU4LS40NDcuMzQ3LS44OS40OS0xLjM0LjEyLS4zNjcuMjE4LS43OTQuMDAyLTEuMTQ1LS4yMi0uMzYtLjY0NC0uNDUtMS4wMzUtLjQ2OC0uNTUtLjAyNi0xLjE3Ni4wNTgtMS43Mi4xMzNsLTEuODQuMjUyQzE1LjM1Ni42OSAxMy40MSAwIDExLjMgMFM3LjI0NS42OSA1LjY3MyAxLjg1OGwtMS44MzctLjI1MmMtLjU0NS0uMDc0LTEuMTctLjE2LTEuNzIyLS4xMzItLjM5LjAyLS44MTQuMTA4LTEuMDM1LjQ2OC0uMjE2LjM1LS4xMTcuNzc4IDAgMS4xNDQuMTQ2LjQ1LjMzNS44OTQuNDkyIDEuMzRsLjAwMi4wMDYuNzY3IDIuMDAzYy0uMzE4Ljk0OC0uNDkgMS45NjItLjQ5IDMuMDE3IDAgMS44NDIuNTMgMy41NzIgMS43NiA0Ljk2OC4xMjIuMTM4LjI0OC4yNy4zOC4zOTdsLS4wMDguMDI3Yy0uNjA0LjA2Ni0xLjIyMi0uMjA0LTEuNTc1LS43NS0uMDQ3LS4wNzMtLjA3LS4yLS4wOTQtLjI4My0uMDM3LS4xMzItLjA4NS0uMjU1LS4xNi0uMzcyLS4zNTItLjU0NS0xLjA4LS43MDItMS42MjYtLjM1LS42MjUuNDA0LS42MyAxLjA2Mi0uMzQgMS42NzQuMDY4LjE0NS4xNS4yODQuMjM3LjQxOC44NDMgMS4zMDUgMi4zOSAxLjg4IDMuODIzIDEuNTUuMDYuMTY3LjEyMy4zMjcuMTg0LjQ3Mi0uMjUuMDM3LS41MDQuMDMzLS43Mi0uMDA4bC0uMjk4LS4wNTYtLjExNS4yOGMtLjIzMy41NzQtLjMzNSAxLjE4NS0uMjggMS44MDNsLjAyNS4yNjMgMS4zMjggMS41NDVjLS4wMjIuMDEtLjA0My4wMTctLjA2NS4wMjVsLS41NC4xOS4zNjYuNDE0LjE0LjE1MiAxLjM0IDEuNDg0LjAzNi4wNC4wMzcuMDM4LjA0LjA0LjAzNi4wNC4wNC4wNC4wNC4wMzcuMDQuMDM2LjA0Mi4wNC4wNC4wMzcuMDQzLjAzNy4wNDMuMDM3LjA0My4wMzcuMDQ1LjAzNi4wNDUuMDM2LjA0NS4wMzYuMDQ2LjAzNS4wNDguMDM2LjA0Ny4wMzUuMDQ4LjAzNC4wNS4wMzQuMDQ4LjAzNC4wNS4wMzQuMDUuMDMzLjA1Mi4wMzMuMDUuMDMyLjA1My4wMzIuMDUyLjAzLjA1NC4wMzIuMDU1LjAzLjA1NS4wMzQuMDcuMDM4LjE3LjA5NC4wNjUuMDM1LjIzLS4yNDIuMDMtLjAyOC4wMy0uMDI3LjAzNS0uMDI3LjAzNi0uMDI2LjAzNy0uMDI1LjA0LS4wMjQuMDQyLS4wMjMuMDQzLS4wMjIuMDQ1LS4wMi4wNDYtLjAyLjA0Ny0uMDIuMDUtLjAxNy4wNS0uMDE2LjA1LS4wMTQuMDUzLS4wMTMuMDUzLS4wMS4wNTQtLjAxLjA1NS0uMDEuMDU1LS4wMDUuMDU1LS4wMDUuMDU2LS4wMDNoLjExMmwuMDU2LjAwMi4wNTYuMDA0LjA1NS4wMDYuMDU1LjAwNy4wNTUuMDEuMDU0LjAxLjA1NC4wMTMuMDUzLjAxNS4wMjIuMDA3LjYyNiAxLjI2Ny4yOC4wMzYuMDcyLjAxLjA3NC4wMDguMDcyLjAwOC4wNzMuMDA3LjA3My4wMDguMDcyLjAwNi4wNzMuMDA2LjA3My4wMDUuMDczLjAwNC4wNzQuMDAzLjA3My4wMDMuMDczLjAwM2guMDczbC4wNzIuMDAzaC4wNzNsLjA3My4wMDJoLjQ0OGwuMDczLS4wMDIuMDczLS4wMDJoLjA3M2wuMDczLS4wMDQuMDcyLS4wMDQuMDczLS4wMDQuMDczLS4wMDQuMDczLS4wMDUuMDc0LS4wMDcuMDczLS4wMDYuMDczLS4wMDcuMDczLS4wMDcuMDczLS4wMDguMDczLS4wMDguMDctLjAxLjI4LS4wMzUuNjA2LTEuMjIyYy4wNDgtLjA1LjEtLjA2My4xNS0uMDhsLjA1NC0uMDEuMDU1LS4wMS4wNTUtLjAwOC4wNTUtLjAwNi4wNTYtLjAwNC4wNTctLjAwMmguMTEybC4wNTUuMDAzLjA1Ni4wMDUuMDU2LjAwNi4wNTUuMDA4LjA1NS4wMS4wNTMuMDEuMDUzLjAxNC4wNTMuMDE0LjA1LjAxNi4wNS4wMTcuMDQ3LjAyLjA0Ni4wMi4wNDUuMDIuMDQ0LjAyMi4wNDIuMDIzLjA0LjAyNC4wMzcuMDI1LjAzNi4wMjYuMDMzLjAyNy4wMy4wMjcuMDMuMDI4LjIzLjI0Mi4wNjQtLjAzNS4xNjctLjA5Mi4wNzMtLjA0LjA1NS0uMDMyLjA1NC0uMDMuMDUzLS4wMzIuMDUyLS4wMzIuMDUyLS4wMzIuMDUyLS4wMzMuMDUtLjAzNC4wNS0uMDMzLjA1LS4wMzMuMDUtLjAzNC4wNS0uMDM0LjA0Ny0uMDM1LjA0Ny0uMDM1LjA0Ny0uMDM1LjA0Ni0uMDM1LjA0NS0uMDM2LjA0NS0uMDM2LjA0NC0uMDM2LjA0My0uMDM3LjA0My0uMDM3LjA0My0uMDM4LjA0LS4wMzcuMDQzLS4wMzguMDQtLjAzOC4wNC0uMDQuMDQtLjAzOC4wMzctLjA0LjAzOC0uMDM4LjAzOC0uMDQuMDM2LS4wNCAxLjM0LTEuNDg1Yy4wNDYtLjA1LjA5My0uMS4xNC0uMTUzbC4zNjUtLjQxMy0uNTQtLjE5Yy0uMDIyLS4wMS0uMDQ0LS4wMTctLjA2NS0uMDI2bDEuMzI3LTEuNTQ1LjAyNC0uMjYyYy4wMDYtLjA2LjAxLS4xMi4wMTMtLjE4IDEuMDE2LjM0IDIuMTY4LjQ1NiAyLjk0OC4xMi4wMy0uMDEuMDUzLS4wMjguMDctLjA0OC41OC0uMjc1LjkzLS44NCAxLjA4NS0xLjQ0Ni4xNjctLjY1NS4xMTUtMS4zNzItLjEtMi4wMS0uMTc3LS41My0uNDc3LTEuMDM3LS44OTgtMS40MS0uMzktLjM0Ni0uODg0LS41Ny0xLjQxMy0uNTQtLjA0IDAtLjA4LjAwNS0uMTE4LjAxbC0uMzUzLS42OWMxLjA5Ny0uOTg1IDEuNzI3LTIuMzg2IDEuNzI3LTMuODczLjAwMi0xLjU4NC0uNzA3LTMuMDA0LTEuODI1LTMuOTZ6TTcuODAzIDguNjg3Yy45MzIuMjUgMS41ODUgMS4wMiAxLjczIDEuOTE0QzkuMSA5Ljk3IDguNDQ2IDkuNDggNy42NDggOS4yNjhjLS44LS4yMTQtMS42MDgtLjEyLTIuMy4yMS41NzMtLjcgMS41MjQtMS4wNCAyLjQ1NS0uNzl6bTkuNTUtMS40OWMuMTMyIDAgLjI2LjAxNC4zODUuMDM4LS4yMS4xMDYtLjM1Ni4zMjQtLjM1Ni41NzcgMCAuMzU2LjI4OC42NDQuNjQ0LjY0NC4zNTYgMCAuNjQ0LS4yODguNjQ0LS42NDQgMC0uMDQtLjAwMy0uMDc4LS4wMS0uMTE1LjQuMzU4LjY1Mi44NzguNjUyIDEuNDU3IDAgMS4wOC0uODc2IDEuOTU2LTEuOTU2IDEuOTU2UzE1LjQgMTAuMjM0IDE1LjQgOS4xNTRjLS4wMDItMS4wOC44NzQtMS45NTYgMS45NTQtMS45NTZ6bS01LjEwNCA2LjIyYy4yOS4wNC42OS0uMjUyLjk3LS40NTUuMzI4LS4yMzcuMjg1LS4wNzcuMDk1LjE1Ny0uMjUuMzA1LS41Mi42MzQtLjkyNi43LS4xMy4wMi0uMjU1LjAxNi0uMzY4LS4wMDItLjE0Ny0uMDI0LS4yNzQtLjA3LS4zNi0uMTE1LS4xNzUtLjA5Mi0uMzEyLS4xMzgtLjQ0NS0uMTM4cy0uMjcuMDQ2LS40NDYuMTM4Yy0uMDg0LjA0NC0uMjEuMDktLjM1OC4xMTUtLjExMy4wMTgtLjIzOC4wMjMtLjM2Ny4wMDItLjQwOC0uMDY2LS42NzctLjM5Ni0uOTI2LS43LS4yMi0uMjctLjE5NC0uMzY1LjA5My0uMTU3LjI4LjIwMy42OC40OTMuOTcuNDU0LjI4My0uMDM3LjUyNy0uMDkuNjg0LS4xOTYuMTQ1LS4wOTguMjE1LS4yNTIuMTY3LS41LS4wMDUtLjAyMy0uMDEtLjA1Mi0uMDEzLS4wODMtLjQ5LS40OS0xLjAxNi0uMzQ2LTEuMTk0LS42NC0uMS0uMTY1LS4wNTYtLjMzLjA2LS40NzUuMzk0LS40OCAyLjI3LS40OCAyLjY2MiAwIC4xMTcuMTQzLjE2LjMxLjA2LjQ3NS0uMTcyLjI4Ni0uNjcuMTU3LTEuMTUuNi0uMDA3LjA0OC0uMDEyLjA5Mi0uMDIuMTI0LS4wNDcuMjQ4LjAxMy40MDIuMTUuNSAwIC4wMDIgMCAuMDAzLjAwMi4wMDMuMTQ2LjEwNS4zNzguMTU3LjY2LjE5NHptLS4zMjIgNi40OTVjLjc0LjY0OCAxLjY1OC40MSAyLjQ4NS0uNzItLjc5Ny40LTEuNjM3LjY0LTIuNDg1Ljcyem0tMS4yNTUgMGMtLjc0LjY0OC0xLjY1OC40MS0yLjQ4NS0uNzIuNzk3LjQgMS42MzcuNjQgMi40ODUuNzJ6bTEyLjQxLTQuMDc2Yy4zOTIgMS4xNy4wNzYgMi40MTMtLjcwNyAyLjc3Mi0uNzgzLjM2LTEuNzM3LS4zLTIuMTMtMS40Ny0uMzkyLTEuMTctLjA3Ni0yLjQxMy43MDctMi43NzMuNzgyLS4zNiAxLjczNi4zIDIuMTMgMS40N3ptLTMuNzk3LS40MmMuMDkzLjAzNi4xOS4wNTMuMjkuMDUtLjEyMi42MS0uMDYyIDEuMjY1LjEzNSAxLjg1Mi4xOC41My40NzggMS4wMzcuOSAxLjQxbC4wNDYuMDRjLTEuMDAyLS4xMTMtMS43OTItLjQ3Ny0yLjM1OC0xLjA0LS4wNzItLjYyNC43NjQtMi4yNi45ODgtMi4zMTJ6TTYuNjg0IDE4Ljg2Yy0uNzk1LS4wODQtMS4xNTgtLjYzNi0xLjQ0NS0xLjIzMi4yMTItLjAzMy40MzQtLjEwMi42My0uMTkyaC4wMmMuNDMuNDcuODkzLjg3MiAxLjM3OCAxLjIxLS4wNTYuMTYzLS4yMjYuMjUtLjU4NC4yMTR6TTIuMDIgMTQuMzQzYy40My42NjYgMS4xNyAxLjAxIDEuOTEuOTY2LjAwNi4zMS4wNzYuNjUuMTcyLjk4My0xLjIzNy4yNjgtMi41NjYtLjIzNS0zLjI5My0xLjM2LS4yOC0uNDM0LS42MS0xLjA4Ni0uMDM1LTEuNDU4LjMzMi0uMjE1Ljc3Ni0uMTIuOTkuMjEzLjEzNS4yMDcuMTEzLjQzNC4yNTUuNjU1em0xNS4xODUgOC4xODNjLS40MzMuNTE4LS44Ni45NjItMS40NDMgMS4zM2wuNzA3LS44OTJjLjI1LS4xMzYuNDk3LS4yNzguNzM1LS40Mzh6bS0xMC4zNSAxLjMyNmMtLjU2OC0uMzY1LS45NzQtLjgxLTEuNDQtMS4zMjUuMjM3LjE2LjQ4NC4zLjczNC40MzdsLjcwNC44ODh6bS4zNi4yMTJsLS45NjMtMS4yMTJjLjQ1NC0uNDk4IDEuMjc4LS42NjMgMS45NS0uNTQ2bC42ODMgMS4yNjYtLjAxMy0uMDAyYy0uNTgzLS4wOC0xLjI0LjA1Ni0xLjY1OC40OTR6bTEuMjA2LTEuNzA4Yy41NTIuMTYyIDEuMjQuNjc2LjkzIDEuMzU1LS4wODQtLjAzOC0uMTctLjA2Ny0uMjYtLjA5MmwtLjY3LTEuMjYyem00LjY5NyAxLjYzbC0uNDMyLjkzM2MtLjkxLjExNS0xLjg0LjExNS0yLjc1IDBsLS40MzItLjkzNGMxLjE4LjE1NSAyLjQzNC4xNTUgMy42MTQgMHptLjMyNC0uMzRjLS4wNTYuMDE4LS4xMTQuMDQtLjE3LjA2NS0uMjgtLjYxMy4yNy0xLjEzLjgyLTEuMzJsLS42NSAxLjI1NXptMS45NjUuNDE3Yy0uNDM1LS40NTctMS4xMi0uNTg2LTEuNzI0LS40OGwtLjAxOC4wMDMuNjUtMS4yNmMuNjktLjE1MiAxLjU3Ny4wMDIgMi4wNTUuNTI1bC0uOTYyIDEuMjEzek00LjgyNSAyMC45OWwtMS40MDgtMS42MThoLjAwNWMuMzctLjA3Ljc3NC0uMDU1IDEuMTMuMDY2LjM1Ny4xMi43NS4zOTcuNzQ1LjgxMy0uMDA2LjMwOC0uMjE0LjU2LS40Ny43NHptMTIuOTcgMGwxLjQwOC0xLjYxOGgtLjAwNWMtLjM3LS4wNy0uNzc0LS4wNTUtMS4xMy4wNjYtLjM1Ny4xMi0uNzUyLjM5Ny0uNzQ1LjgxMy4wMDYuMzA4LjIxNS41Ni40Ny43NHptLTEzLjIxLTMuNDM0Yy0uMzEuMDU4LS42MzYuMDYzLS45NDQuMDA0LS4yMTguNTM4LS4zIDEuMDg3LS4yNTIgMS42MjguODYtLjE2IDEuNzM0LjEyNyAyLjAxLjY5LjI4LjU3Ny0uMTU0IDEuMjQtLjk5IDEuNTM0LjEzMi4xNDguMjc2LjI5Mi40My40M2wzLjMtMS42MmMtLjI0NC0uMjUyLS40Mi0uNTM2LS41MS0uODQtLjAzNS0uMDUtLjA3LS4xMDUtLjEwNC0uMTU4LS4yNDYuMTk0LS41OC4yMy0uOS4xOTctMS4wNjItLjExLTEuNTYtLjgyLTEuOTctMS43MTItLjAyMi0uMDQ1LS4wNDUtLjA5Ni0uMDctLjE1MnptMTMuMzEgNC4xODRjLjExMi0uMTA3LjIxOC0uMjE3LjMxNy0uMzI4LS44MzUtLjI5NS0xLjI3LS45NTctLjk4OC0xLjUzMy4yNzUtLjU2NSAxLjE0Ny0uODUgMi4wMS0uNjkyLjAwOC0uMDk0LjAxMi0uMTkuMDEyLS4yODQtLjY2LS4yNjUtMS4yMjctLjYyLTEuNTQ2LS45OS0uMTc1LS4yMDQtLjMyNC0uNDIzLS40NS0uNjU0LS4wODYtLjA1My0uMTY1LS4xMS0uMjM2LS4xNzUtLjQ4LjU3OC0xLjAwMyAxLjA2OC0xLjU2IDEuNDdsLS4wMS4wMmMtLjEyOC4yNTUtLjI3NC41MTItLjQ0Ljc1OC0uMDczLjI4My0uMjIuNTUtLjQzLjc5bDMuMzIgMS42MTd6bS02LjU4NSAyLjE2M2MuNi4wMSAxLjItLjAyNCAxLjc5Ny0uMTAzLS4zMDUtLjY0OC4xMi0xLjM0My45OTgtMS42MS44NjctLjI2MyAxLjg5My0uMDIyIDIuNDA0LjU0Mi40Ni0uMjUuODY2LS41MzMgMS4yMTUtLjgzOGwtMy4zMDUtMS42MDhjLS42NzMuNjUyLTEuODE1IDEuMDgtMy4xMSAxLjA4LTEuMjMzIDAtMi4zMjYtLjM4Ny0zLjAxLS45ODdsLTMuMjg3IDEuNjE0Yy4zMjIuMjY3LjY4OC41MTQgMS4xLjczOC41MS0uNTY0IDEuNTM2LS44MDYgMi40MDMtLjU0Mi44OC4yNjcgMS4zMDMuOTYyLjk5OCAxLjYxLjU5NC4wOCAxLjE5Ny4xMTMgMS43OTYuMTAzem05LjA0Ni0xMC45NzJsLjQ1My44ODZjLS4wMy4wMS0uMDU4LjAyNC0uMDg3LjAzNy0uMzA1LjE0LS41NDguMzYtLjczMy42MjVsLS41MDgtLjk5MmMtLjY0Mi4zMTYtMS4zNjQuNDk0LTIuMTI4LjQ5NC0yLjY2NCAwLTQuODI1LTIuMTYtNC44MjUtNC44MjVzMi4xNi00LjgyNiA0LjgyNC00LjgyNmMyLjY2NSAwIDQuODI2IDIuMTYgNC44MjYgNC44MjUgMCAxLjUzLS43MTMgMi44OTItMS44MjQgMy43NzZ6TTE3LjM1NCA1LjRjMi4wNzMgMCAzLjc1MyAxLjY4MiAzLjc1MyAzLjc1NHMtMS42OCAzLjc1My0zLjc1MyAzLjc1M2MtMi4wNzIgMC0zLjc1My0xLjY4LTMuNzUzLTMuNzUzIDAtMi4wNzMgMS42ODItMy43NTMgMy43NTQtMy43NTN6TTExLjMuNTY2YzEuOTggMCAzLjgwNi42NDcgNS4yODQgMS43NGwxLjQxLS4xMjhjLjYyNi0uMDg2IDEuMjU1LS4xODYgMS44ODYtLjIzIDEuODk4LS4xMzQgMS4zNDYuNTMzLjcxMyAyLjMyNmwtLjI0LjYyM2MtLjM1LS4yNDctLjczLS40NTItMS4xMzYtLjYwOC0uMTEtLjE2OC0uMjI1LS4zMzItLjM0NC0uNDkyLjA0LS4wNS4wODQtLjEwMi4xMjgtLjE1My41NzctLjY2IDEuMjYtMS4xMTYgMS45MjQtMS4zMzgtMS4xOTgtLjA5OC0yLjAzNS43ODMtMi42MzggMS42NTJsLjA2NC4wODJjLS4zMjItLjA2NC0uNjU1LS4wOTYtLjk5Ni0uMDk2LTIuODc2IDAtNS4yMDggMi4zMzItNS4yMDggNS4yMDhzMi4zMzIgNS4yMDggNS4yMDggNS4yMDhjLjM0IDAgLjY4LS4wMzMgMS4wMTItLjEtMS42MjQgMS42ODMtNC4xODQgMi41MTgtNy4wNjUgMi41MTgtNC45MDcgMC04Ljg4Ni0yLjQyLTguODg2LTcuMzMgMC0yLjA4Ny43Mi00LjAwNyAxLjkyNy01LjUyNC0uNTY3LS44NzMtMS40OC0xLjgwMy0yLjY2NC0xLjYyLjY2NS4yMjIgMS4zNDguNjc4IDEuOTIzIDEuMzM4LjA0My4wNS4wODUuMTAyLjEyNy4xNTMtLjQ1Ny42MTMtLjg0IDEuMjgtMS4xNCAxLjk5MmwtLjU4LTEuNTEzQzEuMzggMi40OTcuODMyIDEuODI2IDIuNjcgMS45NDRjLjU2OC4wMzYgMS4xMzYuMTE1IDEuNzAyLjE5Ny41NTIuMDggMS4wOTMuMTI1IDEuNjUuMTYzQzcuNDk2IDEuMjEgOS4zMi41NjUgMTEuMy41NjV6bTYuMDU0IDUuMjE4Yy0xLjg2IDAtMy4zNyAxLjUxLTMuMzcgMy4zN3MxLjUxIDMuMzcgMy4zNyAzLjM3IDMuMzctMS41MSAzLjM3LTMuMzctMS41MS0zLjM3LTMuMzctMy4zN3ptMS43NjIgOC40OWMuMDctLjA4Ni4xNC0uMTcyLjIwNi0uMjZsLjQyMi44MjRjLS4wNzYuMDQ3LS4xNTUuMDc1LS4yMjQuMDYtLjIwNi0uMDQtLjM0Ni0uNDEtLjQwNC0uNjI0eiIvPjxwYXRoIGQ9Ik0yNi44MDIgMTYuODk1Yy4xOTQuMTEuNDEzLjIyLjY1Ni4zMjMuMjQzLjEwNC41MDQuMTkuNzgyLjI2cy41NjMuMTA0Ljg1NS4xMDRjLjE4IDAgLjM2OC0uMDE0LjU2My0uMDQyLjE5NS0uMDI4LjM2NS0uMDgzLjUxLS4xNjcuMTQ3LS4wODMuMjctLjE5NC4zNjYtLjMzMy4wOTctLjE0LjE0Ni0uMzIuMTQ2LS41NDIgMC0uNDAzLS4xNTYtLjY5LS40Ny0uODY1LS4zMTItLjE3NC0uNzgtLjMyMy0xLjQwNi0uNDQ4LS40MDMtLjA4My0uNzkyLS4xOTQtMS4xNjctLjMzMy0uMzc1LS4xNC0uNzEtLjMyMy0xLS41NTMtLjI5My0uMjMtLjUyNi0uNTE4LS43LS44NjYtLjE3My0uMzQ3LS4yNi0uNzctLjI2LTEuMjdzLjExLS45NC4zMzMtMS4zMTRjLjIyMi0uMzc1LjUxOC0uNjk1Ljg4Ni0uOTYuMzY4LS4yNjMuNzk1LS40NiAxLjI4Mi0uNTkzLjQ4Ny0uMTMyLjk5NC0uMTk4IDEuNTIyLS4xOTguNTU2IDAgMS4wNTMuMDQgMS40OS4xMjQuNDM4LjA4NC44MTcuMTk1IDEuMTM2LjMzNC42MS4yNS45My41NzcuOTYuOTggMCAuMjEtLjA2Ny40NTUtLjIuNzQtLjEzLjI4NS0uMjc0LjU1Mi0uNDI3LjgwMi0uMTQtLjExLS4zMS0uMjI2LS41MTItLjM0NC0uMi0uMTE4LS40MjctLjIzLS42NzctLjMzNC0uMjUtLjEwNC0uNTEtLjE5LS43OC0uMjYtLjI3Mi0uMDctLjU0Ny0uMTA1LS44MjUtLjEwNS0uMTUzIDAtLjMxMy4wMS0uNDguMDMtLjE2Ni4wMjItLjMxNS4wNjMtLjQ0Ny4xMjZzLS4yNDMuMTUzLS4zMzMuMjdjLS4wOS4xMi0uMTM1LjI3NS0uMTM1LjQ3IDAgLjQ3Mi41MDcuODIgMS41MiAxLjA0Mi40MTguMDgzLjgzLjE5IDEuMjQuMzIzLjQxLjEzMi43OC4zMTYgMS4xMDYuNTUyLjMyNy4yMzYuNTkuNTM1Ljc5Mi44OTYuMi4zNi4zMDIuODEzLjMwMiAxLjM1NSAwIC41NTctLjEwOCAxLjA1LS4zMjMgMS40OC0uMjE1LjQzMi0uNTEuNzkzLS44ODYgMS4wODUtLjM3NC4yOTItLjgxNS41MTQtMS4zMjMuNjY3LS41MDcuMTUzLTEuMDYuMjMtMS42NTcuMjMtLjYxIDAtMS4xMy0uMDQ2LTEuNTUzLS4xMzYtLjQyNC0uMDktLjc3NS0uMTk4LTEuMDUzLS4zMjMtLjE5NS0uMDgzLS40MDctLjIwNS0uNjM2LS4zNjUtLjIzLS4xNi0uMzQ0LS4zOC0uMzQ0LS42NTcgMC0uMjM1LjA3LS40ODIuMjA4LS43NC4xNC0uMjU2LjMtLjUyMy40OC0uOC4xMjYuMTEuMjguMjMuNDYuMzU1em04Ljg4LTExLjEzMmMuODEzIDAgMS40NzIuNjYgMS40NzIgMS40NzMgMCAuODE0LS42NiAxLjQ3My0xLjQ3MyAxLjQ3My0uODEzIDAtMS40NzItLjY2LTEuNDcyLTEuNDc0cy42Ni0xLjQ3MyAxLjQ3My0xLjQ3M3pNMzQuMzQ3IDkuMzljLjA0LS4wMTQuMTU2LS4wMy4zNDQtLjA1Mi4xODctLjAyLjM5Mi0uMDMuNjE1LS4wMy4yMjIgMCAuNDQ1LjAyLjY2Ny4wNi4yMjMuMDQzLjQyNC4xMjMuNjA1LjI0LjE4LjEyLjMyNi4yODYuNDM3LjUwMi4xMS4yMTUuMTY3LjQ5Ny4xNjcuODQ0djguNDJjLS4wNTYuMDMtLjE4LjA1LS4zNzUuMDY0LS4xOTUuMDE0LS40MDQuMDItLjYyNi4wMi0uMjc4IDAtLjUyOC0uMDIzLS43NS0uMDcyLS4yMjMtLjA1LS40MTUtLjE0LS41NzQtLjI3LS4xNi0uMTMzLS4yODUtLjMxLS4zNzYtLjUzMy0uMDktLjIyMi0uMTM1LS41MDctLjEzNS0uODU1VjkuMzloLS4wMDJ6bTQuMTY4LTMuMTA2Yy4wOTctLjAxNC4yMDItLjAyOC4zMTMtLjA0LjA5Ni0uMDE1LjItLjAyNS4zMS0uMDMzLjExMi0uMDA2LjIyNC0uMDEuMzM1LS4wMS4yMjIgMCAuNDQ1LjAyMi42NjcuMDYzLjIyMi4wNDIuNDI0LjEyNS42MDUuMjUuMTguMTI1LjMyNi4yOTUuNDM4LjUxLjExLjIxNi4xNjYuNDk4LjE2Ni44NDV2MS40NmgyLjkydjIuMTI1aC0yLjkydjQuNDZjMCAuOTc0LjM5NyAxLjQ2IDEuMTkgMS40Ni4xOTMgMCAuMzc4LS4wMy41NS0uMDk0LjE3NS0uMDYzLjMzLS4xMzMuNDctLjIxLjE0LS4wNzUuMjYtLjE1NS4zNjUtLjI0LjEwNC0uMDgyLjE3Ny0uMTQ1LjIyLS4xODYuMjA3LjMwNi4zNjcuNTcuNDguNzkyLjExLjIyMi4xNjUuNDMuMTY1LjYyNSAwIC4xODItLjA3My4zNi0uMjIuNTMyLS4xNDUuMTc0LS4zNS4zMzQtLjYxNC40OC0uMjY0LjE0Ni0uNTg0LjI2NC0uOTYuMzU0LS4zNzQuMDktLjc4NC4xMzUtMS4yMjguMTM1LS44NjIgMC0xLjUzMi0uMTY2LTIuMDEyLS41LS40OC0uMzMzLS44MTYtLjc3LTEuMDEtMS4zMTItLjA5OC0uMjc4LS4xNi0uNTctLjE4OC0uODc2LS4wMjgtLjMwNi0uMDQyLS42MS0uMDQyLS45MTd2LTkuNjd6bTkuNDIyIDguNTI2Yy4wNTYuNzY0LjI5MiAxLjQuNzEgMS45MDcuNDE2LjUwNyAxLjA3Ni43NiAxLjk4Ljc2LjM0NyAwIC42NTItLjAzNy45MTYtLjExNC4yNjQtLjA3Ni41LS4xNy43MS0uMjguMjA3LS4xMTIuMzg4LS4yMzQuNTQtLjM2Ni4xNTQtLjEzMi4yOTMtLjI1NC40MTgtLjM2NS4xNjcuMjA4LjM0LjQ3Ni41Mi44MDIuMTguMzI3LjI3Mi41OTQuMjcyLjgwMyAwIC4zMDYtLjE3NC41ODQtLjUyLjgzNC0uMjkzLjIyMy0uNzA2LjQxNS0xLjI0Mi41NzQtLjUzNS4xNi0xLjE2NC4yNC0xLjg4Ni4yNC0uNjUzIDAtMS4yOTYtLjA4My0xLjkyOC0uMjUtLjYzMi0uMTY3LTEuMTk1LS40NTgtMS42OS0uODc1LS40OTItLjQxOC0uODkyLS45NzctMS4xOTgtMS42OC0uMzA2LS43LS40Ni0xLjU4Ny0uNDYtMi42NTcgMC0uODc2LjEzNi0xLjYzLjQwNy0yLjI2Mi4yNy0uNjMuNjMzLTEuMTU2IDEuMDg0LTEuNTczLjQ1Mi0uNDE3Ljk2My0uNzIyIDEuNTMzLS45MTcuNTctLjE5NCAxLjE1NC0uMjkyIDEuNzUtLjI5Mi43OCAwIDEuNDQuMTIgMS45OC4zNjUuNTQzLjI0My45ODQuNTcgMS4zMjUuOTguMzQuNDEuNTg3Ljg4Ljc0IDEuNDA3LjE1My41MjguMjMgMS4wODQuMjMgMS42Njh2LjI5MmMwIC4xMS0uMDA0LjIzLS4wMS4zNTRsLS4wMjIuMzY1Yy0uMDA3LjExNy0uMDE3LjIxLS4wMy4yOGgtNi4xMjh6bTMuNjI3LTEuNTYzYzAtLjY2Ny0uMTMtMS4yMS0uMzg2LTEuNjI2LS4yNTgtLjQxNi0uNzItLjYyNC0xLjM4Ny0uNjI0LS41NyAwLTEuMDI1LjE5OC0xLjM2NS41OTQtLjM0LjM5Ni0uNTEuOTQ4LS41MSAxLjY1N2gzLjY0N3pNNTYuMTcyIDE2Ljg5NWMuMTk1LjExLjQxNC4yMi42NTcuMzIzLjI0Mi4xMDQuNTAzLjE5Ljc4LjI2LjI4LjA3LjU2NC4xMDQuODU2LjEwNC4xOCAwIC4zNjgtLjAxNC41NjMtLjA0Mi4xOTMtLjAyOC4zNjQtLjA4My41MS0uMTY3LjE0Ni0uMDgzLjI2OC0uMTk0LjM2NS0uMzMzLjA5Ny0uMTQuMTQ2LS4zMi4xNDYtLjU0MiAwLS40MDMtLjE1NS0uNjktLjQ2OC0uODY1LS4zMTItLjE3NC0uNzgyLS4zMjMtMS40MDctLjQ0OC0uNDAzLS4wODMtLjc5Mi0uMTk0LTEuMTY3LS4zMzMtLjM3NS0uMTQtLjcxLS4zMjMtMS0uNTUzLS4yOTItLjIzLS41MjUtLjUxOC0uNjk4LS44NjYtLjE3NC0uMzQ3LS4yNi0uNzctLjI2LTEuMjdzLjExLS45NC4zMzMtMS4zMTRjLjIyMi0uMzc1LjUxNy0uNjk1Ljg4Ni0uOTYuMzY3LS4yNjMuNzk1LS40NiAxLjI4LS41OTMuNDg3LS4xMzIuOTk1LS4xOTggMS41MjMtLjE5OC41NTYgMCAxLjA1Mi4wNCAxLjQ5LjEyNC40MzguMDg0LjgxNy4xOTUgMS4xMzYuMzM0LjYxLjI1LjkzLjU3Ny45NTguOTggMCAuMjEtLjA2Ny40NTUtLjE5OC43NC0uMTMyLjI4NS0uMjc0LjU1Mi0uNDI4LjgwMi0uMTM4LS4xMS0uMzEtLjIyNi0uNTEtLjM0NC0uMjAyLS4xMTgtLjQyOC0uMjMtLjY3OC0uMzM0LS4yNS0uMTA0LS41MS0uMTktLjc4Mi0uMjYtLjI3LS4wNy0uNTQ1LS4xMDUtLjgyMy0uMTA1LS4xNTQgMC0uMzE0LjAxLS40OC4wMy0uMTY4LjAyMi0uMzE3LjA2My0uNDUuMTI2LS4xMy4wNjMtLjI0Mi4xNTMtLjMzMy4yNy0uMDkuMTItLjEzNS4yNzUtLjEzNS40NyAwIC40NzIuNTA3LjgyIDEuNTIyIDEuMDQyLjQxNy4wODMuODMuMTkgMS4yNC4zMjMuNDEuMTMyLjc3OC4zMTYgMS4xMDUuNTUyLjMyNS4yMzYuNTkuNTM1Ljc5Ljg5Ni4yLjM2Mi4zLjgxNC4zIDEuMzU2IDAgLjU1Ni0uMTA4IDEuMDUtLjMyMyAxLjQ4LS4yMTUuNDMtLjUxLjc5Mi0uODg2IDEuMDg0LS4zNzQuMjkyLS44MTUuNTE0LTEuMzIzLjY2Ny0uNTA3LjE1My0xLjA2LjIzLTEuNjU3LjIzLS42MSAwLTEuMTMtLjA0Ni0xLjU1My0uMTM2LS40MjQtLjA5LS43NzUtLjE5OC0xLjA1My0uMzIzLS4xOTUtLjA4My0uNDA2LS4yMDUtLjYzNi0uMzY1LS4yMy0uMTYtLjM0NC0uMzgtLjM0NC0uNjU4IDAtLjIzNi4wNy0uNDgzLjIwOC0uNzQuMTQtLjI1Ny4zLS41MjQuNDgtLjgwMi4xMjcuMTEuMjguMjMuNDYuMzU1ek02My43NSA5LjM5Yy4wNy0uMDE0LjE1My0uMDI4LjI1LS4wNDIuMDgzLS4wMTQuMTgtLjAyNC4yOTItLjAzLjExLS4wMDguMjQzLS4wMTIuMzk2LS4wMTIuNDU4IDAgLjg0OC4wNzcgMS4xNjcuMjMuMzIuMTUyLjUyLjQxLjYwNS43Ny4yMjItLjI2NC41Ny0uNTMgMS4wNDItLjgwMi40NzMtLjI3IDEuMDctLjQwNiAxLjc5My0uNDA2LjUxNCAwIDEuMDA0LjA4NyAxLjQ3LjI2LjQ2NS4xNzQuODc4LjQ1NiAxLjI0Ljg0NS4zNi4zOS42NS45MDMuODY1IDEuNTQzLjIxNS42NC4zMjMgMS40MjQuMzIzIDIuMzU2IDAgMS4wODQtLjEyNSAxLjk3Ny0uMzc1IDIuNjc4LS4yNS43MDItLjU3MyAxLjI1OC0uOTcgMS42NjgtLjM5Ni40MS0uODM3LjY5OC0xLjMyNC44NjUtLjQ4Ni4xNjctLjk3My4yNS0xLjQ2LjI1LS40MDIgMC0uNzUzLS4wNDUtMS4wNS0uMTM2LS4zLS4wOS0uNTUzLS4xOS0uNzYyLS4zMDItLjIxLS4xMS0uMzY4LS4yMjItLjQ4LS4zMzRzLS4xOC0uMTg3LS4yMDgtLjIyOHYzLjE1M0g2My43NVY5LjM5em0yLjgzNSA3LjMxN2MuMTEuMTEuMzEuMjQzLjU5NC4zOTYuMjg0LjE1My42MTQuMjMuOTkuMjMuNzA4IDAgMS4yMy0uMjggMS41NjMtLjgzNS4zMzMtLjU1Ni41LTEuMzM0LjUtMi4zMzUgMC0uNDE3LS4wMzUtLjgwNi0uMTA1LTEuMTY3LS4wNy0uMzYtLjE4NC0uNjc0LS4zNDQtLjkzOC0uMTYtLjI2NC0uMzc1LS40Ny0uNjQ2LS42MTUtLjI3LS4xNDYtLjYtLjIyLS45OS0uMjItLjU4NCAwLS45OS4xMTItMS4yMi4zMzUtLjIzLjIyMi0uMzQ0LjQ2NS0uMzQ0LjczdjQuNDJ6TTc3LjA1IDE0LjgxYy4wNTQuNzY0LjI5IDEuNC43MDcgMS45MDcuNDE3LjUwNyAxLjA3OC43NiAxLjk4Ljc2LjM1IDAgLjY1NC0uMDM3LjkyLS4xMTQuMjYzLS4wNzcuNS0uMTcuNzA3LS4yOC4yMS0uMTEyLjM5LS4yMzQuNTQyLS4zNjYuMTUzLS4xMzIuMjkyLS4yNTQuNDE3LS4zNjUuMTY2LjIxLjM0LjQ3Ni41Mi44MDMuMTguMzI3LjI3Mi41OTQuMjcyLjgwMyAwIC4zMDYtLjE3NC41ODMtLjUyLjgzNC0uMjkzLjIyMi0uNzA3LjQxNC0xLjI0Mi41NzMtLjUzNC4xNi0xLjE2NC4yNC0xLjg4Ni4yNC0uNjUzIDAtMS4yOTUtLjA4NC0xLjkyOC0uMjUtLjYzNC0uMTY3LTEuMTk2LS40Ni0xLjY5LS44NzYtLjQ5My0uNDE4LS44OTItLjk3Ny0xLjE5OC0xLjY4LS4zMDYtLjctLjQ2LTEuNTg3LS40Ni0yLjY1NyAwLS44NzYuMTM3LTEuNjMuNDA4LTIuMjYyLjI3LS42My42MzItMS4xNTYgMS4wODMtMS41NzMuNDUyLS40MTcuOTYyLS43MjMgMS41MzItLjkxNy41Ny0uMTk1IDEuMTUzLS4yOTIgMS43NS0uMjkyLjc4IDAgMS40NC4xMiAxLjk4Mi4zNjUuNTQyLjI0My45ODMuNTcgMS4zMjQuOTguMzQuNDEuNTg4Ljg4Ljc0IDEuNDA3cy4yMyAxLjA4NC4yMyAxLjY2OHYuMjkyYzAgLjExLS4wMDMuMjMtLjAxLjM1NGwtLjAyLjM2NWMtLjAwOC4xMTctLjAxOC4yMS0uMDMyLjI4aC02LjEzem0zLjYyNS0xLjU2M2MwLS42NjctLjEyOC0xLjIxLS4zODYtMS42MjYtLjI1OC0uNDE2LS43Mi0uNjI0LTEuMzg3LS42MjQtLjU3IDAtMS4wMjUuMTk4LTEuMzY1LjU5NC0uMzQuMzk2LS41MS45NDgtLjUxIDEuNjU3aDMuNjQ3em02LjI1NCAxLjU2M2MuMDU0Ljc2NC4yOSAxLjQuNzA4IDEuOTA3LjQxNy41MDcgMS4wNzcuNzYgMS45OC43Ni4zNDggMCAuNjU0LS4wMzcuOTE4LS4xMTQuMjY0LS4wNzcuNS0uMTcuNzEtLjI4LjIwNy0uMTEyLjM4OC0uMjM0LjU0LS4zNjYuMTU0LS4xMzIuMjkzLS4yNTQuNDE4LS4zNjUuMTY3LjIxLjM0LjQ3Ni41Mi44MDMuMTgyLjMyNy4yNzIuNTk0LjI3Mi44MDMgMCAuMzA2LS4xNzQuNTgzLS41Mi44MzQtLjI5My4yMjItLjcwNi40MTQtMS4yNC41NzMtLjUzNi4xNi0xLjE2NS4yNC0xLjg4Ny4yNC0uNjU1IDAtMS4yOTctLjA4NC0xLjkzLS4yNS0uNjMyLS4xNjctMS4xOTUtLjQ2LTEuNjg4LS44NzYtLjQ5My0uNDE4LS44OTItLjk3Ny0xLjItMS42OC0uMzA0LS43LS40NTgtMS41ODctLjQ1OC0yLjY1NyAwLS44NzYuMTM2LTEuNjMuNDA3LTIuMjYyLjI3Mi0uNjMuNjM0LTEuMTU2IDEuMDg1LTEuNTczLjQ1LS40MTcuOTYyLS43MjMgMS41MzItLjkxNy41Ny0uMTk1IDEuMTU0LS4yOTIgMS43NTItLjI5Mi43NzcgMCAxLjQzNy4xMiAxLjk4LjM2NS41NC4yNDMuOTgyLjU3IDEuMzIzLjk4LjM0LjQxLjU4Ny44OC43NCAxLjQwNy4xNTQuNTI4LjIzIDEuMDg0LjIzIDEuNjY4di4yOTJjMCAuMTEtLjAwMy4yMy0uMDEuMzU0bC0uMDIyLjM2NWMtLjAwNS4xMTctLjAxNi4yMS0uMDMuMjhoLTYuMTN6bTMuNjI2LTEuNTYzYzAtLjY2Ny0uMTMtMS4yMS0uMzg2LTEuNjI2LS4yNTctLjQxNi0uNzItLjYyNC0xLjM4Ni0uNjI0LS41NyAwLTEuMDI1LjE5OC0xLjM2Ni41OTQtLjM0LjM5Ni0uNTEuOTQ4LS41MSAxLjY1N2gzLjY0OHptMTAuMTcyLTEuMzc2Yy0uMTEtLjExLS4zMDItLjI0Mi0uNTczLS4zOTUtLjI3LS4xNTMtLjU4Ny0uMjMtLjk0OC0uMjMtLjcyMyAwLTEuMjU3LjI2NS0xLjYwNS43OTMtLjM0OC41MjgtLjUyIDEuMjg1LS41MiAyLjI3MiAwIC40ODYuMDM0LjkyOC4xMDMgMS4zMjQuMDcuMzk2LjE4OC43MzMuMzU1IDEuMDEuMTY2LjI4LjM5LjQ5NC42NjcuNjQ3LjI3OC4xNTQuNjMzLjIzIDEuMDYzLjIzLjQwNCAwIC43NDctLjA4MyAxLjAzMi0uMjUuMjg1LS4xNjcuNDI3LS40MDMuNDI3LS43MXYtNC42OWgtLjAwMnptLjk4IDcuMzhjLS4yMzYgMC0uNDI0LS4wOC0uNTYzLS4yNC0uMTQtLjE2LS4yMS0uMzY1LS4yMS0uNjE1LS4xOTQuMjM2LS41MjQuNDgtLjk5LjczLS40NjUuMjUtMS4wNi4zNzUtMS43OC4zNzUtLjUxNSAwLTEuMDEyLS4wODMtMS40OTItLjI1LS40OC0uMTY3LS45MDYtLjQ0NS0xLjI4LS44MzQtLjM3Ni0uMzktLjY3NS0uOTA3LS44OTctMS41NTMtLjIyMy0uNjQ2LS4zMzQtMS40NS0uMzM0LTIuNDA4IDAtLjk2LjExNS0xLjc4LjM0NC0yLjQ2LjIzLS42OC41MzUtMS4yMzMuOTE3LTEuNjU3LjM4Mi0uNDI0LjgyLS43MzcgMS4zMTQtLjkzOC40OTMtLjIwMiAxLjAxLS4zMDIgMS41NTMtLjMwMi42MjUgMCAxLjE0LjEwOCAxLjU0Mi4zMjMuNDA0LjIxNi43MDIuNDI4Ljg5Ni42Mzd2LTMuODRjLjA5Ny0uMDI4LjI0NC0uMDUuNDM4LS4wNjMuMTk1LS4wMTQuMzctLjAyLjUyLS4wMi4yMjMgMCAuNDUuMDIuNjc4LjA2Mi4yMy4wNDIuNDM0LjEyNS42MTUuMjUuMTguMTI1LjMyMi4yOTUuNDI3LjUxLjEwNC4yMTYuMTU2LjQ5OC4xNTYuODQ1djExLjQ1aC0xLjg1NXpNMTA1LjI1MyAxOS4xNzNjLS4yNzQtLjMtLjQxLS42Ny0uNDEtMS4xMXMuMTQzLS43OTguNDMtMS4wOGMuMjg3LS4yOC42NS0uNDIgMS4wOS0uNDIuNDM4IDAgLjguMTQgMS4wODguNDIuMjkuMjgyLjQzMy42NC40MzMgMS4wOHMtLjEzNy44MDUtLjQxIDEuMWMtLjI3NS4yOTQtLjY0NS40NC0xLjExLjQ0LS40NTMgMC0uODIzLS4xNDMtMS4xMS0uNDN6bTMuNzQtOS41OTdjLjA0LS4wMTQuMTUzLS4wMy4zMzgtLjA1Mi4xODYtLjAyLjM4OC0uMDMuNjA3LS4wMy4yMiAwIC40NC4wMi42NTguMDYuMjIuMDQyLjQxOC4xMi41OTYuMjM3LjE4LjExNy4zMjMuMjgyLjQzMy40OTQuMTEuMjEyLjE2NC40OS4xNjQuODMydjguMzAyYy0uMDU1LjAyNy0uMTc4LjA0OC0uMzcuMDYtLjE5Mi4wMTUtLjM5Ny4wMi0uNjE2LjAyLS4yNzMgMC0uNTItLjAyMy0uNzQtLjA3LS4yMTgtLjA1LS40MDctLjEzOC0uNTY0LS4yNjgtLjE1OC0uMTMtLjI4LS4zMDUtLjM3LS41MjQtLjA4OC0uMjItLjEzMy0uNS0uMTMzLS44NDJWOS41NzZ6bS0uMDA0LTIuMjRjMC0uNDM3LjE0My0uNzk3LjQzLTEuMDc4LjI4OC0uMjguNjQ0LS40MiAxLjA3LS40Mi40MSAwIC43NjMuMTQgMS4wNTcuNDIuMjk1LjI4LjQ0My42NC40NDMgMS4wOCAwIC40MzgtLjE0OC43OTQtLjQ0MyAxLjA2OC0uMjk0LjI3NC0uNjQ3LjQxLTEuMDU4LjQxLS40MjYgMC0uNzgtLjEzNi0xLjA3LS40MS0uMjg3LS4yNzQtLjQzLS42My0uNDMtMS4wN3ptNS4xIDEwLjcyN2MtLjM4NC0uNDgtLjY2NS0xLjAzLS44NDMtMS42NTQtLjE4LS42MjQtLjI2Ny0xLjI4LS4yNjctMS45NjMgMC0uNy4xMDItMS4zNi4zMDgtMS45ODMuMjA1LS42MjMuNTEtMS4xNzIuOTE0LTEuNjQ0LjQwNC0uNDczLjkxNC0uODQ2IDEuNTMyLTEuMTIuNjE2LS4yNzQgMS4zMzYtLjQxIDIuMTU4LS40MS44NjMgMCAxLjYuMTM2IDIuMjEuNDEuNjEuMjc0IDEuMTAyLjY0NCAxLjQ4IDEuMTEuMzc2LjQ2NS42NSAxLjAwNi44MiAxLjYyMi4xNzIuNjE2LjI1OCAxLjI2Ny4yNTggMS45NTJzLS4wODYgMS4zNDMtLjI1NyAxLjk3M2MtLjE3LjYzLS40NTIgMS4xODUtLjg0MiAxLjY2NC0uMzkuNDgtLjg5My44NjQtMS41MSAxLjE1Mi0uNjE1LjI4OC0xLjM2Mi40My0yLjI0LjQzLS44NzYgMC0xLjYyLS4xNC0yLjIzLS40Mi0uNjEtLjI4LTEuMTA3LS42NTMtMS40OS0xLjEyem0yLjcxMi0uODIyYy4yNzQuMTguNjEuMjY4IDEuMDA3LjI2OC40MSAwIC43NS0uMDkgMS4wMTYtLjI2Ny4yNjctLjE3Ny40NzYtLjQxNC42MjctLjcwOC4xNS0uMjk1LjI1My0uNjI3LjMxLS45OTcuMDUzLS4zNy4wOC0uNzQ3LjA4LTEuMTMgMC0uMzctLjAyNy0uNzM2LS4wOC0xLjEtLjA1Ni0uMzYyLS4xNi0uNjgtLjMxLS45NTUtLjE1LS4yNzQtLjM1Ni0uNDk3LS42MTYtLjY2OC0uMjYtLjE3LS41OS0uMjU3LS45ODctLjI1N3MtLjczLjA5LS45OTYuMjY3Yy0uMjY3LjE3OC0uNDguNDA4LS42MzcuNjg4LS4xNTguMjgtLjI3LjYtLjM0Ljk1Ni0uMDY4LjM1Ni0uMTAyLjcyLS4xMDIgMS4wOSAwIC4zNy4wMy43NC4wOTMgMS4xMDguMDYyLjM3LjE2OC43MDIuMzE4Ljk5Ny4xNS4yOTYuMzU1LjUzMy42MTYuNzF6Ii8+PC9nPjwvc3ZnPg==",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 7310
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 2.16299999738112,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.6020000146236302,
+          "wait": 229.84699998050925,
+          "receive": 3.0560000159312324,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.322Z",
+        "time": 235.57499999878928,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/socialmedia/facebook-round.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/socialmedia/facebook-round.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-length",
+              "value": "592"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "5.079ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"250-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/svg+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 592,
+            "mimeType": "image/svg+xml",
+            "text": "PHN2ZyBjbGFzcz0iY3VzdG9tLWljb24iIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHN0eWxlPSJoZWlnaHQ6MTAwcHg7d2lkdGg6MTAwcHgiIHdpZHRoPSIxMDBweCIgaGVpZ2h0PSIxMDBweCI+PGNpcmNsZSBjbGFzcz0ib3V0ZXItc2hhcGUiIGN4PSI1MCIgY3k9IjUwIiByPSI0OCIgZmlsbD0iIzNCNTk5OCIvPjxwYXRoIGNsYXNzPSJpbm5lci1zaGFwZSIgZD0iTTY2LjMzNCAyNS41SDMzLjY2OGMtNC40OTIgMC04LjE2OCAzLjY3Ni04LjE2OCA4LjE2OHYzMi42NjRjMCA0LjQ5NiAzLjY3NSA4LjE2OCA4LjE2NyA4LjE2OGgzMi42NjZjNC40OTMgMCA4LjE2Ny0zLjY3MiA4LjE2Ny04LjE2N1YzMy42N2MwLTQuNDkzLTMuNjc0LTguMTctOC4xNjYtOC4xN3pNNjcuMTYgNTBoLTcuOTczdjIxLjQzOEg1MFY1MGgtNC40Mjh2LTcuMDE0SDUwdi00LjU1NGMwLTYuMTkgMi42Ny05Ljg3IDkuOTQ3LTkuODdoOC4zODZ2Ny41ODhoLTYuODVjLTIuMDMzLS4wMDQtMi4yODUgMS4wNi0yLjI4NSAzLjA0bC0uMDEgMy43OTZoOS4xODdMNjcuMTYgNTB6IiBmaWxsPSIjZjdmN2Y3Ii8+PC9zdmc+Cg==",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 1192
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 1.95400000666268,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.56499999482185,
+          "wait": 230.16500001540447,
+          "receive": 2.890999981900279,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.322Z",
+        "time": 235.50699997576885,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/socialmedia/twitter-round.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/socialmedia/twitter-round.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-length",
+              "value": "923"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "4.334ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"39b-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/svg+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 923,
+            "mimeType": "image/svg+xml",
+            "text": "PHN2ZyBjbGFzcz0iY3VzdG9tLWljb24iIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHN0eWxlPSJoZWlnaHQ6MTAwcHg7d2lkdGg6MTAwcHgiIHdpZHRoPSIxMDBweCIgaGVpZ2h0PSIxMDBweCI+PGNpcmNsZSBjbGFzcz0ib3V0ZXItc2hhcGUiIGN4PSI1MCIgY3k9IjUwIiByPSI0OCIgZmlsbD0iIzAwQUNFRCIvPjxwYXRoIGNsYXNzPSJpbm5lci1zaGFwZSIgZD0iTTc0LjUgMzQuNzE0Yy0xLjgwMi44MDQtMy43NCAxLjM0Ny01Ljc3MyAxLjU5MiAyLjA3NS0xLjI1MiAzLjY3LTMuMjMzIDQuNDItNS41OTUtMS45NDIgMS4xNi00LjA5MyAyLTYuMzgzIDIuNDU1LTEuODM0LTEuOTY1LTQuNDQ3LTMuMTkzLTcuMzM4LTMuMTkzLTUuNTUyIDAtMTAuMDU0IDQuNTI3LTEwLjA1NCAxMC4xMSAwIC43OTQuMDkgMS41NjUuMjYgMi4zMDYtOC4zNTUtLjQyMy0xNS43NjItNC40NDgtMjAuNzItMTAuNTY2LS44NjYgMS40OTQtMS4zNjIgMy4yMy0xLjM2MiA1LjA4NCAwIDMuNTEgMS43NzUgNi42MDQgNC40NzMgOC40MTctMS42NDgtLjA1Mi0zLjItLjUwNy00LjU1My0xLjI2NHYuMTI2YzAgNC45IDMuNDY0IDguOTg2IDguMDYzIDkuOTE2LS44NDQuMjMtMS43My4zNTUtMi42NDguMzU1LS42NDggMC0xLjI3OC0uMDY0LTEuODkyLS4xODIgMS4yOCA0LjAxNyA0Ljk5MiA2Ljk0IDkuMzkgNy4wMjMtMy40NCAyLjcxMi03Ljc3NCA0LjMyOC0xMi40ODQgNC4zMjgtLjgxMyAwLTEuNjEzLS4wNDgtMi40LS4xNCA0LjQ1IDIuODY4IDkuNzM0IDQuNTQzIDE1LjQxIDQuNTQzIDE4LjQ5MiAwIDI4LjYwNC0xNS40MSAyOC42MDQtMjguNzczIDAtLjQzOC0uMDEtLjg3NC0uMDMtMS4zMDggMS45NjQtMS40MjggMy42Ny0zLjIxIDUuMDE3LTUuMjM2eiIgZmlsbD0iI2Y3ZjdmNyIvPjwvc3ZnPgo=",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 1523
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 1.74999999580905,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.5280000041238899,
+          "wait": 230.42799998074807,
+          "receive": 2.8009999950878353,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.322Z",
+        "time": 235.51399999996647,
+        "request": {
+          "method": "GET",
+          "url": "https://run.sitespeed.io/img/socialmedia/github-round.svg",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/img/socialmedia/github-round.svg"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "run.sitespeed.io"
+            },
+            {
+              "name": "cookie",
+              "value": "__cfduid=d245da2ac417451fb9fa0852da7855a6d1435061837; ssioqueue=1; __utma=152498875.1418992272.1383681826.1452810533.1452841975.773; __utmc=152498875; __utmz=152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php; _ga=GA1.2.1418992272.1383681826; _gat=1"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [],
+          "cookies": [
+            {
+              "name": "__cfduid",
+              "value": "d245da2ac417451fb9fa0852da7855a6d1435061837",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "ssioqueue",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmc",
+              "value": "152498875",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "__utmz",
+              "value": "152498875.1450310184.754.50.utmcsr=checkpagerank.net|utmccn=(referral)|utmcmd=referral|utmcct=/index.php",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_ga",
+              "value": "GA1.2.1418992272.1383681826",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            },
+            {
+              "name": "_gat",
+              "value": "1",
+              "expires": null,
+              "httpOnly": false,
+              "secure": false
+            }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 19 Jan 2016 06:46:27 GMT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-response-time",
+              "value": "3.617ms"
+            },
+            {
+              "name": "last-modified",
+              "value": "Mon, 28 Sep 2015 12:04:20 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"6b3-3639237707\""
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-type",
+              "value": "image/svg+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "public, max-age=31536000"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; script-src 'self' 'unsafe-inline' https://www.google-analytics.com"
+            },
+            {
+              "name": "x-proxy-cache",
+              "value": "HIT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 1715,
+            "mimeType": "image/svg+xml",
+            "text": "PHN2ZyBjbGFzcz0iY3VzdG9tLWljb24iIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHN0eWxlPSJoZWlnaHQ6MTAwcHg7d2lkdGg6MTAwcHgiIHdpZHRoPSIxMDBweCIgaGVpZ2h0PSIxMDBweCI+PGNpcmNsZSBjbGFzcz0ib3V0ZXItc2hhcGUiIGN4PSI1MCIgY3k9IjUwIiByPSI0OCIgZmlsbD0iIzNFM0UzRSIvPjxwYXRoIGNsYXNzPSJpbm5lci1zaGFwZSIgZD0iTTUwIDI1LjVjLTEzLjUzIDAtMjQuNSAxMC45Ny0yNC41IDI0LjVTMzYuNDcgNzQuNSA1MCA3NC41IDc0LjUgNjMuNTMgNzQuNSA1MCA2My41MyAyNS41IDUwIDI1LjV6bTE0LjU1IDM5LjA1Yy0xLjg5MiAxLjg5LTQuMDkzIDMuMzc0LTYuNTQyIDQuNDEtLjYyMy4yNjQtMS4yNTUuNDk2LTEuODk1LjY5NVY2NS45OGMwLTEuOTMtLjY2Mi0zLjM1LTEuOTg2LTQuMjU4LjgzLS4wOCAxLjU5LS4xOSAyLjI4NS0uMzM1LjY5NC0uMTQ0IDEuNDI3LS4zNTIgMi4yLS42MjMuNzc0LS4yNzIgMS40NjgtLjU5NSAyLjA4Mi0uOTcuNjE0LS4zNzQgMS4yMDUtLjg2IDEuNzctMS40NnMxLjA0Mi0xLjI3NSAxLjQyNC0yLjAzMy42ODYtMS42NjYuOTEtMi43MjdjLjIyMi0xLjA2LjMzNC0yLjIzLjMzNC0zLjUwNSAwLTIuNDczLS44MDUtNC41NzctMi40MTYtNi4zMTYuNzMzLTEuOTE0LjY1NC0zLjk5Ni0uMjQtNi4yNDVsLS41OTgtLjA3Yy0uNDE0LS4wNDgtMS4xNi4xMjctMi4yMzcuNTI2LTEuMDc1LjQtMi4yODQgMS4wNTItMy42MjMgMS45NjItMS45LS41MjYtMy44NjgtLjc5LTUuOTEtLjc5LTIuMDU4IDAtNC4wMi4yNjQtNS44ODYuNzktLjg0NC0uNTc0LTEuNjQ2LTEuMDQ4LTIuNDA0LTEuNDIzLS43NTctLjM3NS0xLjM2My0uNjMtMS44MTgtLjc2Ni0uNDU1LS4xMzctLjg3Ny0uMjItMS4yNjgtLjI1My0uMzktLjAzMi0uNjQyLS4wNC0uNzU0LS4wMjQtLjExLjAxNi0uMTkuMDMyLS4yNC4wNDgtLjg5MiAyLjI2Ni0uOTcyIDQuMzQ4LS4yMzggNi4yNDYtMS42MSAxLjczOC0yLjQxNiAzLjg0NC0yLjQxNiA2LjMxNiAwIDEuMjc2LjExIDIuNDQ1LjMzNSAzLjUwNS4yMjMgMS4wNi41MjYgMS45Ny45MSAyLjcyOC4zOC43NTcuODU2IDEuNDM1IDEuNDIyIDIuMDMzczEuMTU2IDEuMDg1IDEuNzcgMS40NmMuNjE0LjM3NSAxLjMwOC42OTggMi4wOC45Ny43NzUuMjcgMS41MDguNDc3IDIuMjAyLjYyLjY5NC4xNDUgMS40NTYuMjU3IDIuMjg1LjMzNi0xLjMwOC44OTQtMS45NjIgMi4zMTMtMS45NjIgNC4yNnYzLjc0MmMtLjcyMi0uMjE1LTEuNDM0LS40Ny0yLjEzNC0uNzY1LTIuNDQ4LTEuMDM1LTQuNjUtMi41Mi02LjU0LTQuNDEtMS44OS0xLjg5LTMuMzc1LTQuMDkyLTQuNDEyLTYuNTQyLTEuMDctMi41MzQtMS42MTUtNS4yMjgtMS42MTUtOC4wMDhzLjU0NC01LjQ3NCAxLjYxNi04LjAwOGMxLjAzNS0yLjQ1IDIuNTItNC42NSA0LjQxLTYuNTRzNC4wOTItMy4zNzYgNi41NDItNC40MTNjMi41MzQtMS4wNzMgNS4yMjgtMS42MTYgOC4wMDgtMS42MTZzNS40NzQuNTQzIDguMDA4IDEuNjE1YzIuNDUgMS4wMzYgNC42NSAyLjUyIDYuNTQgNC40MSAxLjg5MiAxLjg5MiAzLjM3NiA0LjA5MyA0LjQxMyA2LjU0MiAxLjA3MiAyLjUzNSAxLjYxNiA1LjIzIDEuNjE2IDguMDA4cy0uNTQ0IDUuNDc0LTEuNjE2IDguMDA4Yy0xLjAzNiAyLjQ1LTIuNTIgNC42NS00LjQxIDYuNTQyeiIgZmlsbD0iI2Y3ZjdmNyIvPjwvc3ZnPgo=",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 1491
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 1.51600001845509,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.5149999924469699,
+          "wait": 230.87699999450695,
+          "receive": 2.6059999945574646,
+          "ssl": -1
+        },
+        "connection": "1043855",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-01-19T06:46:30.394Z",
+        "time": 6.03299998329021,
+        "request": {
+          "method": "GET",
+          "url": "https://www.google-analytics.com/collect?v=1&_v=j40&a=503183539&t=pageview&_s=1&dl=https%3A%2F%2Frun.sitespeed.io%2F&ul=en-us&de=UTF-8&dt=Analyze%20your%20page%20against%20web%20performance%20best%20practice%20rules%20and%20using%20metrics&sd=24-bit&sr=1440x900&vp=1130x229&je=0&fl=20.0%20r0&_utma=152498875.1418992272.1383681826.1452810533.1452841975.773&_utmz=152498875.1450310184.754.50.utmcsr%3Dcheckpagerank.net%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Findex.php&_utmht=1453185990390&_u=AACCAEABI~&jid=&cid=1418992272.1383681826&tid=UA-31246987-3&z=1014282684",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": ":path",
+              "value": "/collect?v=1&_v=j40&a=503183539&t=pageview&_s=1&dl=https%3A%2F%2Frun.sitespeed.io%2F&ul=en-us&de=UTF-8&dt=Analyze%20your%20page%20against%20web%20performance%20best%20practice%20rules%20and%20using%20metrics&sd=24-bit&sr=1440x900&vp=1130x229&je=0&fl=20.0%20r0&_utma=152498875.1418992272.1383681826.1452810533.1452841975.773&_utmz=152498875.1450310184.754.50.utmcsr%3Dcheckpagerank.net%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Findex.php&_utmht=1453185990390&_u=AACCAEABI~&jid=&cid=1418992272.1383681826&tid=UA-31246987-3&z=1014282684"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "dnt",
+              "value": "1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "accept-language",
+              "value": "en-US,en;q=0.8,sv;q=0.6,fi;q=0.4,pt;q=0.2"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            },
+            {
+              "name": "accept",
+              "value": "image/webp,image/*,*/*;q=0.8"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": ":authority",
+              "value": "www.google-analytics.com"
+            },
+            {
+              "name": "referer",
+              "value": "https://run.sitespeed.io/"
+            },
+            {
+              "name": ":scheme",
+              "value": "https"
+            },
+            {
+              "name": ":method",
+              "value": "GET"
+            }
+          ],
+          "queryString": [
+            {
+              "name": "v",
+              "value": "1"
+            },
+            {
+              "name": "_v",
+              "value": "j40"
+            },
+            {
+              "name": "a",
+              "value": "503183539"
+            },
+            {
+              "name": "t",
+              "value": "pageview"
+            },
+            {
+              "name": "_s",
+              "value": "1"
+            },
+            {
+              "name": "dl",
+              "value": "https%3A%2F%2Frun.sitespeed.io%2F"
+            },
+            {
+              "name": "ul",
+              "value": "en-us"
+            },
+            {
+              "name": "de",
+              "value": "UTF-8"
+            },
+            {
+              "name": "dt",
+              "value": "Analyze%20your%20page%20against%20web%20performance%20best%20practice%20rules%20and%20using%20metrics"
+            },
+            {
+              "name": "sd",
+              "value": "24-bit"
+            },
+            {
+              "name": "sr",
+              "value": "1440x900"
+            },
+            {
+              "name": "vp",
+              "value": "1130x229"
+            },
+            {
+              "name": "je",
+              "value": "0"
+            },
+            {
+              "name": "fl",
+              "value": "20.0%20r0"
+            },
+            {
+              "name": "_utma",
+              "value": "152498875.1418992272.1383681826.1452810533.1452841975.773"
+            },
+            {
+              "name": "_utmz",
+              "value": "152498875.1450310184.754.50.utmcsr%3Dcheckpagerank.net%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Findex.php"
+            },
+            {
+              "name": "_utmht",
+              "value": "1453185990390"
+            },
+            {
+              "name": "_u",
+              "value": "AACCAEABI~"
+            },
+            {
+              "name": "jid",
+              "value": ""
+            },
+            {
+              "name": "cid",
+              "value": "1418992272.1383681826"
+            },
+            {
+              "name": "tid",
+              "value": "UA-31246987-3"
+            },
+            {
+              "name": "z",
+              "value": "1014282684"
+            }
+          ],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 15 Jan 2016 13:55:49 GMT"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "last-modified",
+              "value": "Sun, 17 May 1998 03:00:00 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Golfe2"
+            },
+            {
+              "name": "age",
+              "value": "319837"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "content-type",
+              "value": "image/gif"
+            },
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store, must-revalidate"
+            },
+            {
+              "name": "content-length",
+              "value": "35"
+            },
+            {
+              "name": "expires",
+              "value": "Mon, 01 Jan 1990 00:00:00 GMT"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 35,
+            "mimeType": "image/gif",
+            "text": "R0lGODlhAQABAID/AP///wAAACwAAAAAAQABAAACAkQBADs=",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 117
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.59699997655116,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.16600001254119,
+          "wait": 4.03300000471063,
+          "receive": 1.2369999894872308,
+          "ssl": -1
+        },
+        "connection": "1043854",
+        "pageref": "page_5"
+      }
+    ]
+  }
+}

--- a/test/har/performance/mimeTypes.js
+++ b/test/har/performance/mimeTypes.js
@@ -1,0 +1,23 @@
+'use strict';
+
+let assert = require('assert');
+let har = require('../../help/har');
+const harfileCorrect = 'mimeTypesCorrect.har';
+const harfileIncorrect = 'mimeTypesIncorrect.har';
+/*
+In the harfileIncorrect file, the mimeType for the following resources were changed to 'blah''
+https://run.sitespeed.io/img/logos/logoBig2.svg
+*/
+describe('Avoid incorrectly configured mime types', function() {
+  it('We should be able to know incorrect mime types', function() {
+    return har.firstAdviceForTestFile(harfileIncorrect).then((result) => {
+      assert.strictEqual(result.performance.adviceList.mimeTypes.score, 99);
+    });
+  });
+  it('We should be able to know correct mime types', function() {
+    return har.firstAdviceForTestFile(harfileCorrect).then((result) => {
+      assert.strictEqual(result.performance.adviceList.mimeTypes.score, 100);
+      assert.strictEqual(result.performance.adviceList.mimeTypes.offending.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
This is a PR for issue #204 - the advice will check for a success status code and if `asset.type == "other"` it will report as an incorrect mime type.
Tests pass (I reused imageSize2.har as it was the smallest file) as well as linting.

It's not relevant to this PR but I noticed there's no failures in the tests if the har loader helper is given a file that doesn't exist.

-----

I also noticed the build was failing before my commit:
>   1) info - h2 browser: chrome Should be able to know if the connection is H2:

Again a separate issue I can raise but it'd be worth adding the travis build status to the home page readme.