### PR TITLE
Add ability to sort advices based on cli arguments

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -66,6 +66,11 @@ var cli = {
       .option('viewPort', {
         describe: 'Set the browser viewport to WIDTHxHEIGHT.'
       })
+      .option('sortBy', {
+        describe: 'Define sort option for advices.',
+        choices: ['name', 'score'],
+        default: 'name'
+      })
       .wrap(yargs.terminalWidth())
       // .strict()
       .argv;

--- a/lib/table.js
+++ b/lib/table.js
@@ -3,6 +3,7 @@
 var wrap = require('word-wrap');
 
 var Table = require('cli-table2'),
+    sortBy = require('lodash.sortby'),
     chalk = require('chalk');
 
 function getNewTable() {
@@ -55,12 +56,13 @@ class ResultTable {
     let adviceList = this.result.advice[type].adviceList;
     let self = this;
 
-    let sortedAdvice = Object.keys(adviceList).sort();
+    let sortedAdvice = sortBy(adviceList, this.options.sortBy);
+
     sortedAdvice.forEach((advice) => {
-      let score = adviceList[advice].score;
+      let score = advice.score;
       if (score < self.options.limit) {
-        self.table.push([getColoredMessage(score, advice),
-          wrap(adviceList[advice].advice, {
+        self.table.push([getColoredMessage(score, advice.id),
+          wrap(advice.advice, {
             trim: true,
             indent: '',
             width: 53
@@ -71,7 +73,7 @@ class ResultTable {
         if (self.options.description) {
           self.table.push(['Description', {
             colSpan: 2,
-            content: wrap(adviceList[advice].title + '. ' + adviceList[advice].description, {
+            content: wrap(advice.title + '. ' + advice.description, {
               trim: true,
               indent: '',
               width: 63
@@ -80,10 +82,10 @@ class ResultTable {
         }
 
         // show offending if it's configured and we have some assets
-        if (adviceList[advice].offending.length > 0 && self.options.details) {
+        if (advice.offending.length > 0 && self.options.details) {
           self.table.push([{
             colSpan: 3,
-            content: adviceList[advice].offending.join('\n')
+            content: advice.offending.join('\n')
           }]);
         }
       }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lodash.clonedeep": "4.5.0",
     "lodash.groupby": "4.6.0",
     "lodash.merge": "4.6.0",
+    "lodash.sortby": "^4.7.0",
     "pagexray": "0.14.1",
     "word-wrap": "1.1.0",
     "yargs": "6.4.0"


### PR DESCRIPTION
- [x] Check that your change/fix has corresponding unit tests
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`
- [x] Squash commits so it looks sane

### Description
Add the ability to sort advices list based on the cli argument (--sortBy=), if no argument is passed set name as default. This is the pull request for the feature #222 
