### PR TITLE
Run H2 test against global server

### DIFF
--- a/bin/webcoach.js
+++ b/bin/webcoach.js
@@ -22,7 +22,7 @@ function run(options) {
       if (options.browser === 'chrome') {
         options.chrome = {
           mobileEmulation: {
-            deviceName: 'Apple iPhone 6'
+            deviceName: 'iPhone 6'
           }
         };
       } else {

--- a/test/dom/info/h2Test.js
+++ b/test/dom/info/h2Test.js
@@ -16,13 +16,11 @@ describe('info - h2', function() {
       after(() => runner.stop());
 
       it('Should be able to know if the connection is H2', function() {
-        if (browser === 'firefox') {
-          // Skip for now, since Firefox fails for local H2 sites (likely due to self signed cert)
-          this.skip();
-        }
-        return runner.run('connectionType.js').then(result => {
-          assert.strictEqual(result === 'h2', true);
-        });
+        return runner
+          .runGlobalServer('connectionType.js', 'https://www.sitespeed.io/')
+          .then(result => {
+            assert.strictEqual(result === 'h2', true);
+          });
       });
     });
   });

--- a/test/dom/info/indexTest.js
+++ b/test/dom/info/indexTest.js
@@ -32,9 +32,11 @@ describe('Info', function() {
       });
 
       it('We should be able to identify the connection type', function() {
-        return runner.run('connectionType.js').then(result => {
-          assert.strictEqual(result !== 'unknown', true);
-        });
+        return runner
+          .runGlobalServer('connectionType.js', 'https://www.sitespeed.io/')
+          .then(result => {
+            assert.strictEqual(result !== 'unknown', true);
+          });
       });
 
       it('We should be able to find iframes', function() {


### PR DESCRIPTION
We have disabled the H2 test before since it didn't work in Firefox against our local H2 server. And then also the test for connectionType started to fail against our local for FF, so let us test against https://www.sitespeed.io. We will lose total local testing BUT we will test more functionality.
