### PR TITLE
Improve tests to print more diffs on error.

### DIFF
--- a/test/dom/info/h2Test.js
+++ b/test/dom/info/h2Test.js
@@ -19,7 +19,7 @@ describe('info - h2', function() {
         return runner
           .runGlobalServer('connectionType.js', 'https://www.sitespeed.io/')
           .then(result => {
-            assert.strictEqual(result === 'h2', true);
+            assert.strictEqual(result, 'h2');
           });
       });
     });

--- a/test/dom/info/indexTest.js
+++ b/test/dom/info/indexTest.js
@@ -35,7 +35,7 @@ describe('Info', function() {
         return runner
           .runGlobalServer('connectionType.js', 'https://www.sitespeed.io/')
           .then(result => {
-            assert.strictEqual(result !== 'unknown', true);
+            assert.notStrictEqual(result, 'unknown');
           });
       });
 
@@ -90,13 +90,13 @@ describe('Info', function() {
 
       it('We should be able to get the window size', function() {
         return runner.run('windowSize.js').then(result => {
-          assert.strictEqual(typeof result !== 'undefined', true);
+          assert.strictEqual(/^\d+x\d+$/.test(result), true);
         });
       });
 
       it('We should be able to know which browser runs', function() {
         return runner.run('browser.js').then(result => {
-          assert.strictEqual(result !== 'unknown', true);
+          assert.notStrictEqual(result, 'unknown');
         });
       });
 


### PR DESCRIPTION
* Smarter asserts to print actuals when comparing strings.
* Fix window size tests that would never fail (since windowSize.js returned a string). Instead check the format of the returned string.