### PR TITLE
Update google-chrome for Browsertime 3.0

### DIFF
--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-google-chrome-beta --version
+google-chrome --version
 firefox --version
 
 # Here's a hack for fixing the problem with Chrome not starting in time


### PR DESCRIPTION
Since Browsertime 3.0, use google-chrome instead of google-chrome-beta.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Check that your change/fix has corresponding unit tests
- [ ] Verify that the test works by running `npm test` and test linting by `npm run lint`
- [ ] Squash commits so it looks sane

### Description
Please describe your pull request and tell us the fix #

Thank you for helping the coach!
