### PR TITLE
use json parse instead on clonedeep for faster parsing

### DIFF
--- a/lib/har/harCutter.js
+++ b/lib/har/harCutter.js
@@ -1,16 +1,15 @@
 'use strict';
 
-var groupBy = require('lodash.groupby'),
-  cloneDeep = require('lodash.clonedeep');
+var groupBy = require('lodash.groupby');
 
 module.exports.pickAPage = function(har, pageIndex) {
   if (typeof har.log.pages[pageIndex] !== 'undefined') {
-    let myHar = cloneDeep(har);
+    const myHar = JSON.parse(JSON.stringify(har));
 
     // get the ID
-    let pageId = myHar.log.pages[pageIndex].id;
+    const pageId = myHar.log.pages[pageIndex].id;
 
-    let resourcesByPage = groupBy(myHar.log.entries, 'pageref');
+    const resourcesByPage = groupBy(myHar.log.entries, 'pageref');
     myHar.log.entries = resourcesByPage[pageId];
 
     myHar.log.pages = [myHar.log.pages[pageIndex]];

--- a/package-lock.json
+++ b/package-lock.json
@@ -2741,7 +2741,8 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
     },
     "lodash.escape": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "cli-table3": "0.5.0",
     "filter-files": "0.4.0",
     "json-stable-stringify": "1.0.1",
-    "lodash.clonedeep": "4.5.0",
     "lodash.groupby": "4.6.0",
     "lodash.merge": "4.6.0",
     "lodash.sortby": "^4.7.0",


### PR DESCRIPTION
I did a test with a browsertime HAR for 21 pages testing CNET:

Parsing the HAR 21 times took 6 seconds using string/parse. Using clonedeep takes 233 seconds. I guess the first have smarter caching? Using the pickAHar form sitespeed we parse the same HAR over and over so the current version really slow down the runs.

See #293