### PR TITLE
Check for Browsertime errors in run().

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,7 @@ module.exports = {
       ) {
         const browsertimeError = new Error(result.errors);
         browsertimeError.name = 'BROWSERTIMEERROR';
-        return browsertimeError;
+        throw browsertimeError;
       }
       const domAdvice = result.browserScripts[0].coach.domAdvice,
         har = result.har;

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,6 +115,15 @@ module.exports = {
 
     options = merge({}, DEFAULT_OPTIONS, options);
     return runBrowsertime(url, domScript, options).then(result => {
+      if (
+        Array.isArray(result.errors) &&
+        result.errors.length !== 0 &&
+        result.errors[0].length !== 0
+      ) {
+        const browsertimeError = new Error(result.errors);
+        browsertimeError.name = 'BROWSERTIMEERROR';
+        return browsertimeError;
+      }
       const domAdvice = result.browserScripts[0].coach.domAdvice,
         har = result.har;
 


### PR DESCRIPTION
When Coach is run from another script and Browsertime cannot access
Selenium Grid, run() fails with TypeError: coach is undefined from
 result.browserScripts[0].coach. This commit adds rough error checking for
Browsertime errors and returns a new Error object
so the running script can handle the error.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ X ] Check that your change/fix has corresponding unit tests
I do not believe the change requires any changes to unit tests.
- [ X ] Verify that the test works by running `npm test` and test linting by `npm run lint`
npm test and npm run lint run successfully with the change.
- [ X ] Squash commits so it looks sane
The change should be reasonably simple. There is only one commit.

### Description
Please describe your pull request and tell us the fix #

When Browsertime's attempt to connect to Selenium fails or times out, webcoach.run() fails with the following error:

TypeError: Cannot read property 'coach' of undefined
    at runBrowsertime.then.result (/path/to/project/coach-api/node_modules/webcoach/lib/index.js:118:50)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)

I added a rough check for Browsertime errors to enable me to catch when this kind of problem happens in the script that runs webcoach.run(). If the check is too rough or if there is a better way to catch this error in Coach or my application, I would be happy to give writing an error check another go. I would really like to be able to catch this error in my own application, and I certainly want to give it back if it would be helpful to others.

Thank you for helping the coach!
