### PR TITLE
Added flag to run() to return the HAR as JSON in the advice array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,7 +129,7 @@ module.exports = {
   pickAPage(har, pageIndex) {
     return pickAPage(har, pageIndex);
   },
-  async run(url, domScript, harScript, options) {
+  async run(url, domScript, harScript, options, returnHar) {
     if (!domScript) {
       domScript = await this.getDomAdvice();
     }
@@ -154,7 +154,13 @@ module.exports = {
         domAdvice,
         options
       );
-      return this.merge(domAdvice, harAdvice);
+      const advice = this.merge(domAdvice, harAdvice);
+      if (returnHar) {
+        advice.har = result.har;
+      } else {
+        advice.har = {};
+      }
+      return advice;
     } else {
       return domAdvice;
     }

--- a/test/api/runTest.js
+++ b/test/api/runTest.js
@@ -39,4 +39,10 @@ describe('Run API:', function() {
         'score'
       ].forEach(property => advice.advice.should.have.ownProperty(property));
     }));
+  it('should output correct structure with returnHar', () =>
+    api.run(url, null, null, null, true).then(advice => {
+      ['advice', 'errors', 'url', 'version', 'har'].forEach(property =>
+        advice.should.have.ownProperty(property)
+      );
+    }));
 });


### PR DESCRIPTION

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ X ] Check that your change/fix has corresponding unit tests
- [ X ] Verify that the test works by running `npm test` and test linting by `npm run lint`
- [ X ] Squash commits so it looks sane

### Description
Please describe your pull request and tell us the fix #
I currently use the Coach programmatically and display the results for a given analyzed web page. I would like to be able to use and to display the HAR data as well. It seems like that would be a useful thing for me to be able to do. When running the coach programmatically, passing true as the 5th param will make the HAR part of the advice if the HAR was in the result from runBrowserTime(). If the HAR data is not available, the advice is returned without the HAR data.

I do think the Coach is a great tool! I have really enjoyed using it. I wanted to give this bit of functionality back in case it might be something useful to others using the Coach programmatically.